### PR TITLE
Add validation/retry to variable clarification

### DIFF
--- a/src/udiagent/data/skills/clarify_variable.md
+++ b/src/udiagent/data/skills/clarify_variable.md
@@ -1,11 +1,11 @@
 ---
 name: clarify_variable
-description: Generate a clarification request when the user references ambiguous variables
+description: Generate a clarification request when the user's query is ambiguous
 ---
 
-# Clarify Variable
+# Clarify
 
-The user's request references one or more ambiguous variables that could match multiple fields or entities in the dataset. Generate a clarification response.
+The user's request is ambiguous. Generate a clarification response.
 
 ## User Request
 
@@ -21,14 +21,20 @@ The user's request references one or more ambiguous variables that could match m
 
 ## Instructions
 
-Respond with a JSON object containing exactly two keys:
+There are two kinds of clarification:
 
-1. **"message"**: A polite, natural-language explanation of what is ambiguous and why clarification is needed. Be specific about which terms are ambiguous and what the possible interpretations are.
-2. **"ambiguous_variables"**: An array of objects, one per ambiguous term. Each object must have:
+- **variable** — the ambiguity is about which schema field the user means. Candidates MUST reference actual `(entity, field_name)` pairs from the data schema. Use the bare field name (e.g. `sex`), never a qualified name (e.g. `donor.sex`).
+- **general** — the ambiguity is not about a schema field (for example, asking which chart type the user wants). Candidates can be free-form option labels, and `entity` may be an empty string.
+
+Respond with a JSON object containing exactly three keys:
+
+1. **"clarification_type"**: either `"variable"` or `"general"`, per the distinction above.
+2. **"message"**: A polite natural-language explanation of what is ambiguous and why clarification is needed.
+3. **"ambiguous_variables"**: An array of objects, one per ambiguous term. Each object must have:
    - `"query_term"`: The term from the user's request that is ambiguous
    - `"candidates"`: An array of candidate matches, each with only:
-     - `"field_name"`: The actual field name in the schema
-     - `"entity"`: Which dataset entity (table) this field belongs to
-   Do NOT include data_type or description — those are added automatically from the schema.
+     - `"field_name"`: For variable clarifications, the schema field name. For general clarifications, the option label.
+     - `"entity"`: For variable clarifications, which dataset entity (table) the field belongs to. For general clarifications, an empty string.
+   Do NOT include data_type or description — those are added automatically from the schema for variable clarifications.
 
 Respond with only the JSON object. Do not include any explanation or markdown formatting.

--- a/src/udiagent/data/skills/orchestrate.md
+++ b/src/udiagent/data/skills/orchestrate.md
@@ -25,6 +25,10 @@ You are YAC (Yet Another Chatbot), a helpful assistant that investigates data. B
 
 Only call `CreateVisualization` when the user is asking for a **new or different** chart, not when they are refining or filtering an existing one.
 
+## Do not clarify filter ranges
+
+When the user asks to filter an interval (numeric or date) field, do **not** call `ClarifyVariable` to ask which range they mean. Pick a reasonable default range from the field's domain and call `FilterData` directly — the user can refine the bounds with the adjustment widget after the filter is applied. Reserve clarification for cases where the field itself is ambiguous.
+
 ## Available Dataset Domains
 
 {{data_domains}}

--- a/src/udiagent/orchestrator.py
+++ b/src/udiagent/orchestrator.py
@@ -22,6 +22,38 @@ from udiagent.tools import (
 logger = logging.getLogger(__name__)
 
 
+def _build_schema_field_meta(schema_raw: dict) -> dict:
+    """Map (entity, field_name) → {data_type, description} from a raw schema dict."""
+    meta: dict = {}
+    for resource in schema_raw.get("resources", []):
+        entity_name = resource.get("name", "")
+        for field_def in resource.get("schema", {}).get("fields", []):
+            fname = field_def.get("name", "")
+            meta[(entity_name, fname)] = {
+                "data_type": field_def.get("udi:data_type", "unknown"),
+                "description": field_def.get("description", "").strip(),
+            }
+    return meta
+
+
+def _validate_variable_candidates(
+    ambiguous_variables: list, valid_keys: set
+) -> list[str]:
+    """Return a list of human-readable errors for candidates that don't match the schema."""
+    errors: list[str] = []
+    for var in ambiguous_variables:
+        query_term = var.get("query_term", "?")
+        for candidate in var.get("candidates", []):
+            entity = candidate.get("entity", "")
+            field = candidate.get("field_name", "")
+            if (entity, field) not in valid_keys:
+                errors.append(
+                    f"Candidate for '{query_term}': (entity={entity!r}, field_name={field!r}) "
+                    f"is not in the schema. Use the bare field name only."
+                )
+    return errors
+
+
 @dataclass
 class OrchestratorResult:
     """Result of an orchestration run."""
@@ -250,41 +282,133 @@ class Orchestrator:
         openai_api_key=None,
     ):
         clarification_type = tool_args.get("clarification_type", "variable")
+
+        if clarification_type != "variable":
+            return {
+                "name": "ClarifyVariable",
+                "arguments": {
+                    "clarification_type": clarification_type,
+                    "message": tool_args.get("message", ""),
+                    "ambiguous_variables": tool_args.get("ambiguous_variables", []),
+                    "validation_retries": 0,
+                },
+            }
+
+        try:
+            schema_raw = (
+                json.loads(data_schema) if isinstance(data_schema, str) else data_schema
+            )
+        except (json.JSONDecodeError, TypeError):
+            schema_raw = {}
+
+        field_meta = _build_schema_field_meta(schema_raw)
+        valid_keys = set(field_meta.keys())
+
+        validation_retries = 0
         ambiguous_variables = tool_args.get("ambiguous_variables", [])
+        message = tool_args.get("message", "")
 
-        if clarification_type == "variable":
-            try:
-                schema_raw = (
-                    json.loads(data_schema) if isinstance(data_schema, str) else data_schema
+        errors = _validate_variable_candidates(ambiguous_variables, valid_keys)
+        if errors:
+            retried = self._retry_clarify_variable(
+                prev_tool_args={
+                    "clarification_type": "variable",
+                    "message": message,
+                    "ambiguous_variables": ambiguous_variables,
+                },
+                errors=errors,
+                messages=messages,
+                data_domains=data_domains,
+                openai_api_key=openai_api_key,
+            )
+            validation_retries = 1
+            if retried is not None:
+                ambiguous_variables = retried.get(
+                    "ambiguous_variables", ambiguous_variables
                 )
-            except (json.JSONDecodeError, TypeError):
-                schema_raw = {}
+                message = retried.get("message", message)
 
-            field_meta = {}
-            for resource in schema_raw.get("resources", []):
-                entity_name = resource.get("name", "")
-                for field_def in resource.get("schema", {}).get("fields", []):
-                    fname = field_def.get("name", "")
-                    field_meta[(entity_name, fname)] = {
-                        "data_type": field_def.get("udi:data_type", "unknown"),
-                        "description": field_def.get("description", "").strip(),
-                    }
-
-            for var in ambiguous_variables:
-                for candidate in var.get("candidates", []):
-                    key = (candidate.get("entity", ""), candidate.get("field_name", ""))
-                    meta = field_meta.get(key, {})
-                    candidate["data_type"] = meta.get("data_type", "unknown")
-                    candidate["description"] = meta.get("description", "")
+        for var in ambiguous_variables:
+            for candidate in var.get("candidates", []):
+                key = (candidate.get("entity", ""), candidate.get("field_name", ""))
+                meta = field_meta.get(key, {})
+                candidate["data_type"] = meta.get("data_type", "unknown")
+                candidate["description"] = meta.get("description", "")
 
         return {
             "name": "ClarifyVariable",
             "arguments": {
-                "clarification_type": clarification_type,
-                "message": tool_args.get("message", ""),
+                "clarification_type": "variable",
+                "message": message,
                 "ambiguous_variables": ambiguous_variables,
+                "validation_retries": validation_retries,
             },
         }
+
+    def _retry_clarify_variable(
+        self,
+        prev_tool_args,
+        errors,
+        messages,
+        data_domains,
+        openai_api_key,
+    ):
+        """Re-invoke the LLM constrained to ClarifyVariable with error feedback.
+
+        Returns the corrected tool arguments dict, or None on failure.
+        """
+        orchestrate_skill = self.skills.get("orchestrate")
+        if orchestrate_skill is None:
+            return None
+
+        clarify_tool = next(
+            (t for t in self.tools if t["function"]["name"] == "ClarifyVariable"),
+            None,
+        )
+        if clarify_tool is None:
+            return None
+
+        rendered = render_template(
+            orchestrate_skill.instructions,
+            {"data_domains": simplify_data_domains(data_domains)},
+        )
+        retry_msgs = normalize_tool_calls(copy.deepcopy(messages))
+        retry_msgs.insert(0, {"role": "system", "content": rendered})
+        hint = "The previous tool call had errors:\n" + "\n".join(
+            f"- {e}" for e in errors
+        )
+        retry_msgs.append(
+            {
+                "role": "assistant",
+                "content": f"Tool call: ClarifyVariable({json.dumps(prev_tool_args)})",
+            }
+        )
+        retry_msgs.append(
+            {
+                "role": "user",
+                "content": hint
+                + "\n\nReturn a corrected ClarifyVariable call. Use bare field names from the schema, never qualified names like 'entity.field'.",
+            }
+        )
+
+        gpt_client = self.agent._get_gpt_client(openai_api_key)
+        try:
+            resp = gpt_client.chat.completions.create(
+                model=self.agent.gpt_model_name,
+                messages=retry_msgs,
+                tools=[clarify_tool],
+                tool_choice={
+                    "type": "function",
+                    "function": {"name": "ClarifyVariable"},
+                },
+                temperature=0.0,
+                max_completion_tokens=1024,
+            )
+            tc = resp.choices[0].message.tool_calls[0]
+            return json.loads(tc.function.arguments)
+        except Exception as exc:
+            logger.warning("ClarifyVariable retry failed: %s", exc)
+            return None
 
     def _handle_filter_data(
         self,

--- a/src/udiagent/orchestrator.py
+++ b/src/udiagent/orchestrator.py
@@ -249,34 +249,38 @@ class Orchestrator:
         data_domains,
         openai_api_key=None,
     ):
-        try:
-            schema_raw = (
-                json.loads(data_schema) if isinstance(data_schema, str) else data_schema
-            )
-        except (json.JSONDecodeError, TypeError):
-            schema_raw = {}
-
-        field_meta = {}
-        for resource in schema_raw.get("resources", []):
-            entity_name = resource.get("name", "")
-            for field_def in resource.get("schema", {}).get("fields", []):
-                fname = field_def.get("name", "")
-                field_meta[(entity_name, fname)] = {
-                    "data_type": field_def.get("udi:data_type", "unknown"),
-                    "description": field_def.get("description", "").strip(),
-                }
-
+        clarification_type = tool_args.get("clarification_type", "variable")
         ambiguous_variables = tool_args.get("ambiguous_variables", [])
-        for var in ambiguous_variables:
-            for candidate in var.get("candidates", []):
-                key = (candidate.get("entity", ""), candidate.get("field_name", ""))
-                meta = field_meta.get(key, {})
-                candidate["data_type"] = meta.get("data_type", "unknown")
-                candidate["description"] = meta.get("description", "")
+
+        if clarification_type == "variable":
+            try:
+                schema_raw = (
+                    json.loads(data_schema) if isinstance(data_schema, str) else data_schema
+                )
+            except (json.JSONDecodeError, TypeError):
+                schema_raw = {}
+
+            field_meta = {}
+            for resource in schema_raw.get("resources", []):
+                entity_name = resource.get("name", "")
+                for field_def in resource.get("schema", {}).get("fields", []):
+                    fname = field_def.get("name", "")
+                    field_meta[(entity_name, fname)] = {
+                        "data_type": field_def.get("udi:data_type", "unknown"),
+                        "description": field_def.get("description", "").strip(),
+                    }
+
+            for var in ambiguous_variables:
+                for candidate in var.get("candidates", []):
+                    key = (candidate.get("entity", ""), candidate.get("field_name", ""))
+                    meta = field_meta.get(key, {})
+                    candidate["data_type"] = meta.get("data_type", "unknown")
+                    candidate["description"] = meta.get("description", "")
 
         return {
             "name": "ClarifyVariable",
             "arguments": {
+                "clarification_type": clarification_type,
                 "message": tool_args.get("message", ""),
                 "ambiguous_variables": ambiguous_variables,
             },

--- a/src/udiagent/tools.py
+++ b/src/udiagent/tools.py
@@ -46,15 +46,27 @@ ORCHESTRATOR_TOOLS = [
         "function": {
             "name": "ClarifyVariable",
             "description": (
-                "Use this tool when the user's request references an ambiguous variable "
-                "that could match multiple fields or entities in the dataset. For example, "
-                "'age' might match 'age_value' in donors or 'sample_age' in samples. "
-                "Returns a clarification request with candidate variables for the user "
-                "to choose from."
+                "Use this tool when the user's request is ambiguous and needs "
+                "clarification before a visualization or filter can be produced. "
+                "Set clarification_type to 'variable' when the ambiguity is about "
+                "which schema field the user means (e.g., 'age' might match "
+                "'age_value' in donors or 'sample_age' in samples). Set it to "
+                "'general' for other clarifications, such as asking which chart "
+                "type the user wants. Candidates for 'variable' clarifications "
+                "must reference actual schema (entity, field_name) pairs and "
+                "will be validated; 'general' candidates are free-form labels."
             ),
             "parameters": {
                 "type": "object",
                 "properties": {
+                    "clarification_type": {
+                        "type": "string",
+                        "enum": ["variable", "general"],
+                        "description": (
+                            "'variable' when asking which schema field the user meant; "
+                            "'general' for any other clarification (e.g. chart type)."
+                        ),
+                    },
                     "message": {
                         "type": "string",
                         "description": "A natural-language explanation of what is ambiguous and why clarification is needed.",
@@ -75,26 +87,32 @@ ORCHESTRATOR_TOOLS = [
                                         "properties": {
                                             "field_name": {
                                                 "type": "string",
-                                                "description": "The actual field name in the schema.",
+                                                "description": (
+                                                    "For 'variable' clarifications: the bare field name in the schema (e.g. 'sex', not 'donor.sex'). "
+                                                    "For 'general' clarifications: a free-form option label (e.g. 'bar chart')."
+                                                ),
                                             },
                                             "entity": {
                                                 "type": "string",
-                                                "description": "The dataset entity this field belongs to.",
+                                                "description": (
+                                                    "For 'variable' clarifications: the dataset entity this field belongs to. "
+                                                    "For 'general' clarifications: may be an empty string."
+                                                ),
                                             },
                                         },
                                         "required": ["field_name", "entity"],
                                         "additionalProperties": False,
                                     },
-                                    "description": "Candidate fields that could match the ambiguous term.",
+                                    "description": "Candidate options for the ambiguous term.",
                                 },
                             },
                             "required": ["query_term", "candidates"],
                             "additionalProperties": False,
                         },
-                        "description": "List of ambiguous variables with their candidate matches.",
+                        "description": "List of ambiguous terms with their candidate matches.",
                     },
                 },
-                "required": ["message", "ambiguous_variables"],
+                "required": ["clarification_type", "message", "ambiguous_variables"],
                 "additionalProperties": False,
             },
         },

--- a/tests/test_clarify_variable_validation.py
+++ b/tests/test_clarify_variable_validation.py
@@ -1,0 +1,198 @@
+"""Tests for variable clarification schema validation and retry."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from udiagent.orchestrator import (
+    Orchestrator,
+    _validate_variable_candidates,
+    _build_schema_field_meta,
+)
+
+
+PENGUIN_SCHEMA = {
+    "resources": [
+        {
+            "name": "penguins",
+            "schema": {
+                "fields": [
+                    {"name": "sex", "udi:data_type": "nominal", "description": "Sex of the penguin."},
+                    {"name": "species", "udi:data_type": "nominal", "description": "Species name."},
+                    {"name": "body_mass_g", "udi:data_type": "quantitative", "description": "Body mass in grams."},
+                ]
+            },
+        }
+    ]
+}
+
+
+class TestCandidateValidation:
+    def test_valid_candidates_produce_no_errors(self):
+        schema_meta = _build_schema_field_meta(PENGUIN_SCHEMA)
+        candidates = [
+            {
+                "query_term": "sex",
+                "candidates": [{"entity": "penguins", "field_name": "sex"}],
+            }
+        ]
+        assert _validate_variable_candidates(candidates, set(schema_meta.keys())) == []
+
+    def test_qualified_name_is_rejected(self):
+        schema_meta = _build_schema_field_meta(PENGUIN_SCHEMA)
+        candidates = [
+            {
+                "query_term": "sex",
+                "candidates": [{"entity": "penguins", "field_name": "penguins.sex"}],
+            }
+        ]
+        errors = _validate_variable_candidates(candidates, set(schema_meta.keys()))
+        assert len(errors) == 1
+        assert "penguins.sex" in errors[0]
+
+    def test_wrong_entity_is_rejected(self):
+        schema_meta = _build_schema_field_meta(PENGUIN_SCHEMA)
+        candidates = [
+            {
+                "query_term": "sex",
+                "candidates": [{"entity": "donors", "field_name": "sex"}],
+            }
+        ]
+        errors = _validate_variable_candidates(candidates, set(schema_meta.keys()))
+        assert len(errors) == 1
+
+
+class TestHandlerRetryFlow:
+    def _make_orchestrator(self):
+        from udiagent.agent import UDIAgent
+
+        agent = UDIAgent.__new__(UDIAgent)
+        agent.gpt_model = MagicMock(name="default_gpt_model")
+        agent.gpt_model_name = "gpt-4.1"
+        agent._get_gpt_client = MagicMock(return_value=agent.gpt_model)
+        orch = Orchestrator.__new__(Orchestrator)
+        orch.agent = agent
+        # Minimal orchestrate skill for retry prompt rendering
+        from udiagent.skills import load_skills
+        orch.skills = load_skills()
+        from udiagent.tools import ORCHESTRATOR_TOOLS
+        orch.tools = ORCHESTRATOR_TOOLS
+        return orch, agent
+
+    def test_malformed_qualified_name_triggers_retry(self):
+        orch, agent = self._make_orchestrator()
+
+        retry_corrected_args = {
+            "clarification_type": "variable",
+            "message": "Which 'sex' did you mean?",
+            "ambiguous_variables": [
+                {
+                    "query_term": "sex",
+                    "candidates": [
+                        {"entity": "penguins", "field_name": "sex"},
+                    ],
+                }
+            ],
+        }
+        retry_response = MagicMock()
+        retry_response.choices = [
+            MagicMock(
+                message=MagicMock(
+                    tool_calls=[
+                        MagicMock(
+                            function=MagicMock(
+                                arguments=json.dumps(retry_corrected_args)
+                            )
+                        )
+                    ]
+                )
+            )
+        ]
+        agent.gpt_model.chat.completions.create = MagicMock(return_value=retry_response)
+
+        initial_tool_args = {
+            "clarification_type": "variable",
+            "message": "Which one?",
+            "ambiguous_variables": [
+                {
+                    "query_term": "sex",
+                    "candidates": [
+                        {"entity": "penguins", "field_name": "penguins.sex"},
+                    ],
+                }
+            ],
+        }
+
+        result = orch._handle_clarify_variable(
+            initial_tool_args,
+            messages=[{"role": "user", "content": "show sex"}],
+            data_schema=json.dumps(PENGUIN_SCHEMA),
+            data_domains="[]",
+            openai_api_key=None,
+        )
+
+        args = result["arguments"]
+        assert args["validation_retries"] == 1
+        candidates = args["ambiguous_variables"][0]["candidates"]
+        assert candidates[0]["field_name"] == "sex"
+        # Enrichment happened on the corrected candidate
+        assert candidates[0]["data_type"] == "nominal"
+
+    def test_valid_input_does_not_retry(self):
+        orch, agent = self._make_orchestrator()
+        agent.gpt_model.chat.completions.create = MagicMock(
+            side_effect=AssertionError("retry should not be invoked")
+        )
+
+        tool_args = {
+            "clarification_type": "variable",
+            "message": "Which one?",
+            "ambiguous_variables": [
+                {
+                    "query_term": "sex",
+                    "candidates": [{"entity": "penguins", "field_name": "sex"}],
+                }
+            ],
+        }
+        result = orch._handle_clarify_variable(
+            tool_args,
+            messages=[],
+            data_schema=json.dumps(PENGUIN_SCHEMA),
+            data_domains="[]",
+            openai_api_key=None,
+        )
+        assert result["arguments"]["validation_retries"] == 0
+
+    def test_general_type_skips_validation(self):
+        orch, agent = self._make_orchestrator()
+        agent.gpt_model.chat.completions.create = MagicMock(
+            side_effect=AssertionError("retry should not be invoked for general")
+        )
+
+        tool_args = {
+            "clarification_type": "general",
+            "message": "Which chart type?",
+            "ambiguous_variables": [
+                {
+                    "query_term": "chart",
+                    "candidates": [
+                        {"entity": "", "field_name": "bar chart"},
+                        {"entity": "", "field_name": "scatter plot"},
+                    ],
+                }
+            ],
+        }
+        result = orch._handle_clarify_variable(
+            tool_args,
+            messages=[],
+            data_schema=json.dumps(PENGUIN_SCHEMA),
+            data_domains="[]",
+            openai_api_key=None,
+        )
+        args = result["arguments"]
+        assert args["clarification_type"] == "general"
+        assert args["validation_retries"] == 0
+        # No enrichment for general type
+        candidate = args["ambiguous_variables"][0]["candidates"][0]
+        assert "data_type" not in candidate


### PR DESCRIPTION
## Summary
- Split ClarifyVariable into two modes via a new ``clarification_type`` discriminator: ``variable`` (schema-field ambiguity) and ``general`` (any other clarification, e.g. chart type).
- Validate ``variable`` clarification candidates against the data schema; if any candidate doesn't match an actual ``(entity, field_name)`` pair, feed the errors back to the LLM and retry the tool call once. Retry pattern mirrors the visualization generator at ``src/udiagent/vis_generate.py:411-446``.
- Forbid filter-range clarification in the orchestrate prompt — the adjustment widget already handles range refinement.

## Changes
- ``src/udiagent/tools.py`` — ``ClarifyVariable`` gains a required ``clarification_type`` field (enum: ``variable`` | ``general``) and updated description/parameter docs.
- ``src/udiagent/orchestrator.py`` — ``_handle_clarify_variable`` now branches on ``clarification_type``; the variable path validates candidates against the schema via new helpers ``_build_schema_field_meta`` and ``_validate_variable_candidates``, retries once on failure via ``_retry_clarify_variable`` (focused LLM call constrained to ClarifyVariable), and exposes ``validation_retries`` on the result.
- ``src/udiagent/data/skills/clarify_variable.md`` — prompt teaches both clarification types and constrains variable candidates to schema ``(entity, field_name)`` pairs (never qualified like ``donor.sex``).
- ``src/udiagent/data/skills/orchestrate.md`` — new section forbids ClarifyVariable for filter ranges and directs the LLM to pick a default range + FilterData instead.
- ``tests/test_clarify_variable_validation.py`` — unit tests for candidate validation, the retry flow (including qualified-name correction), the no-retry fast path, and the general-type pass-through.

## Spec
``.claude/todo/done/add-validation-retry-to-variable-clarification.md`` (archived after merge). Design choice for the decoupling: single tool with a ``clarification_type`` discriminator, per the spec author's annotation.

## Frontend coordination
``NickAkhmetov/udi-chat-react`` should read ``clarification_type`` to decide whether to render variable descriptions. ``variable`` clarifications carry enriched ``data_type``/``description`` metadata; ``general`` clarifications do not.

## Test plan
- [x] ``uv run pytest tests/`` — 12 passed (6 new).
- [ ] Manual: trigger a query with an ambiguous field name and confirm the clarification returns schema-validated candidates with descriptions.
- [ ] Manual: intentionally prompt the LLM to return a qualified candidate (``donor.sex``) and confirm ``validation_retries=1`` and corrected bare field names.
- [ ] Manual: ask a chart-type clarification question (e.g. \"bar or scatter?\") and confirm ``clarification_type='general'`` with free-form labels and no enrichment.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)