### PR TITLE
Improve agent filter management with modify/remove actions

### DIFF
--- a/src/udiagent/benchmark/runner.py
+++ b/src/udiagent/benchmark/runner.py
@@ -281,6 +281,35 @@ def check_filter_rubric(rubric, expected, output, data_domains):
         call for call in output_tool_calls if call["name"] == "FilterData"
     ][0]["arguments"]
 
+    expected_action = expected_filter_call_args.get("action", "add")
+    output_action = output_filter_call_args.get("action", "add")
+    update_rubric(
+        rubric, "filter_action", expected_action, output_action, "filter", 10
+    )
+
+    # Remove actions carry no filterType/values — stop here after checking
+    # entity and field, which are still required for remove.
+    if expected_action == "remove":
+        output_filter_entity = output_filter_call_args["entity"]
+        update_rubric(
+            rubric,
+            "filter_entity_correct",
+            expected_filter_call_args["entity"],
+            output_filter_entity,
+            "filter",
+            20,
+        )
+        output_filter_field = output_filter_call_args["field"]
+        update_rubric(
+            rubric,
+            "filter_field_correct",
+            expected_filter_call_args["field"],
+            output_filter_field,
+            "filter",
+            20,
+        )
+        return rubric
+
     # correct type of filter (point vs range): 40 points
     expected_filter_type = expected_filter_call_args["filter"]["filterType"]
     output_filter_type = output_filter_call_args["filter"]["filterType"]

--- a/src/udiagent/data/skills/orchestrate.md
+++ b/src/udiagent/data/skills/orchestrate.md
@@ -25,6 +25,20 @@ You are YAC (Yet Another Chatbot), a helpful assistant that investigates data. B
 
 Only call `CreateVisualization` when the user is asking for a **new or different** chart, not when they are refining or filtering an existing one.
 
+## Filter Management
+
+Filters are managed with the `FilterData` tool, which takes an `action`:
+
+- **add** — introduce a new filter on a previously-unfiltered field.
+- **modify** — change the values/range of an existing filter (same entity and field).
+- **remove** — clear an existing filter; only `action`, `entity`, and `field` are needed.
+
+Filters are identified by their `(entity, field)` pair. Each pair may have at most one active filter — re-filtering an already-filtered field must use `modify`, not `add`. Consult the **Current Filters** list below before choosing an action. If the user asks to undo or drop a filter, use `remove`. If the user asks to change an existing filter's values, use `modify`.
+
+## Current Filters
+
+{{current_filters}}
+
 ## Available Dataset Domains
 
 {{data_domains}}

--- a/src/udiagent/orchestrator.py
+++ b/src/udiagent/orchestrator.py
@@ -22,6 +22,116 @@ from udiagent.tools import (
 logger = logging.getLogger(__name__)
 
 
+def _build_schema_field_meta(schema_raw: dict) -> dict:
+    """Map (entity, field_name) → {data_type, description} from a raw schema dict."""
+    meta: dict = {}
+    for resource in schema_raw.get("resources", []):
+        entity_name = resource.get("name", "")
+        for field_def in resource.get("schema", {}).get("fields", []):
+            fname = field_def.get("name", "")
+            meta[(entity_name, fname)] = {
+                "data_type": field_def.get("udi:data_type", "unknown"),
+                "description": field_def.get("description", "").strip(),
+            }
+    return meta
+
+
+def _format_current_filters(current_filters: list[dict]) -> str:
+    """Render the current-filters list into a compact, LLM-friendly block."""
+    if not current_filters:
+        return "(none — no filters are currently applied)"
+    lines = []
+    for idx, f in enumerate(current_filters, start=1):
+        entity = f.get("entity", "?")
+        field = f.get("field", "?")
+        filt = f.get("filter", {}) or {}
+        ftype = filt.get("filterType", "?")
+        if ftype == "interval":
+            rng = filt.get("intervalRange", {}) or {}
+            detail = f"range [{rng.get('min', '?')}, {rng.get('max', '?')}]"
+        elif ftype == "point":
+            vals = filt.get("pointValues", []) or []
+            detail = f"values {vals}"
+        else:
+            detail = ""
+        title = f.get("title", "").strip()
+        title_suffix = f" — {title}" if title else ""
+        lines.append(
+            f"{idx}. entity={entity}, field={field}, type={ftype}, {detail}{title_suffix}"
+        )
+    return "\n".join(lines)
+
+
+def _validate_filter_action(
+    tool_args: dict, schema_keys: set, current_filters: list[dict]
+) -> list[str]:
+    """Validate a FilterData tool call against the schema and current filters."""
+    errors: list[str] = []
+    action = tool_args.get("action", "add")
+    entity = tool_args.get("entity", "")
+    field = tool_args.get("field", "")
+
+    if action not in ("add", "modify", "remove"):
+        errors.append(f"Unknown action {action!r}; expected 'add', 'modify', or 'remove'.")
+        return errors
+
+    if schema_keys and (entity, field) not in schema_keys:
+        errors.append(
+            f"({entity!r}, {field!r}) is not a valid (entity, field) pair in the schema."
+        )
+
+    current_keys = {(f.get("entity", ""), f.get("field", "")) for f in current_filters}
+    target_key = (entity, field)
+
+    if action == "add" and target_key in current_keys:
+        errors.append(
+            f"Filter on ({entity!r}, {field!r}) already exists. "
+            f"Use action='modify' to change it instead of 'add'."
+        )
+    if action in ("modify", "remove") and target_key not in current_keys:
+        errors.append(
+            f"No existing filter on ({entity!r}, {field!r}); cannot {action}. "
+            f"Use action='add' for a new filter."
+        )
+
+    if action in ("add", "modify"):
+        ftype = tool_args.get("filterType")
+        if ftype not in ("point", "interval"):
+            errors.append(
+                f"filterType must be 'point' or 'interval' for action={action!r}; got {ftype!r}."
+            )
+        elif ftype == "point" and not tool_args.get("pointValues"):
+            errors.append(
+                f"action={action!r} with filterType='point' requires non-empty pointValues."
+            )
+        elif ftype == "interval" and not tool_args.get("intervalRange"):
+            errors.append(
+                f"action={action!r} with filterType='interval' requires intervalRange."
+            )
+
+    return errors
+
+
+def _build_filter_payload(tool_args: dict, validation_retries: int) -> dict:
+    """Shape the outgoing FilterData tool-call arguments for the frontend."""
+    action = tool_args.get("action", "add")
+    payload = {
+        "action": action,
+        "title": tool_args.get("title", ""),
+        "entity": tool_args.get("entity", ""),
+        "field": tool_args.get("field", ""),
+        "validation_retries": validation_retries,
+    }
+    if action == "remove":
+        return payload
+    payload["filter"] = {
+        "filterType": tool_args.get("filterType", "point"),
+        "intervalRange": tool_args.get("intervalRange", {"min": 0, "max": 0}),
+        "pointValues": tool_args.get("pointValues", [""]),
+    }
+    return payload
+
+
 @dataclass
 class OrchestratorResult:
     """Result of an orchestration run."""
@@ -61,6 +171,7 @@ class Orchestrator:
         messages: list[dict],
         data_schema: str,
         data_domains: str,
+        current_filters: list[dict] | None = None,
         openai_api_key: str | None = None,
     ) -> OrchestratorResult:
         """Run the orchestrator on a user request.
@@ -69,6 +180,11 @@ class Orchestrator:
             messages: Chat history (OpenAI message format).
             data_schema: JSON string describing dataset entities and fields.
             data_domains: JSON string (or list) describing field domains.
+            current_filters: The currently-applied filters (as a list of dicts
+                with at least ``entity``, ``field``, and ``filter``). Passed
+                explicitly into the orchestrate prompt so the LLM can decide
+                between add/modify/remove actions without inferring state
+                from message history.
             openai_api_key: Optional per-request OpenAI key override.
 
         Returns:
@@ -79,6 +195,7 @@ class Orchestrator:
             msgs,
             data_schema,
             data_domains,
+            current_filters=current_filters or [],
             openai_api_key=openai_api_key,
         )
         return OrchestratorResult(tool_calls=tool_calls, orchestrator_choice=choice)
@@ -288,22 +405,103 @@ class Orchestrator:
         messages,
         data_schema,
         data_domains,
+        current_filters=None,
         openai_api_key=None,
     ):
-        filter_obj = {
-            "filterType": tool_args["filterType"],
-            "intervalRange": tool_args.get("intervalRange", {"min": 0, "max": 0}),
-            "pointValues": tool_args.get("pointValues", [""]),
-        }
+        current_filters = current_filters or []
+        validation_retries = 0
+
+        try:
+            schema_raw = (
+                json.loads(data_schema) if isinstance(data_schema, str) else data_schema
+            )
+        except (json.JSONDecodeError, TypeError):
+            schema_raw = {}
+        schema_keys = set(_build_schema_field_meta(schema_raw).keys())
+
+        errors = _validate_filter_action(tool_args, schema_keys, current_filters)
+        if errors:
+            retried = self._retry_filter_data(
+                prev_tool_args=tool_args,
+                errors=errors,
+                messages=messages,
+                data_domains=data_domains,
+                current_filters=current_filters,
+                openai_api_key=openai_api_key,
+            )
+            validation_retries = 1
+            if retried is not None:
+                tool_args = retried
+
         return {
             "name": "FilterData",
-            "arguments": {
-                "title": tool_args.get("title", ""),
-                "entity": tool_args["entity"],
-                "field": tool_args["field"],
-                "filter": filter_obj,
-            },
+            "arguments": _build_filter_payload(tool_args, validation_retries),
         }
+
+    def _retry_filter_data(
+        self,
+        prev_tool_args,
+        errors,
+        messages,
+        data_domains,
+        current_filters,
+        openai_api_key,
+    ):
+        """Re-invoke the LLM constrained to FilterData with error feedback."""
+        orchestrate_skill = self.skills.get("orchestrate")
+        if orchestrate_skill is None:
+            return None
+        filter_tool = next(
+            (t for t in self.tools if t["function"]["name"] == "FilterData"),
+            None,
+        )
+        if filter_tool is None:
+            return None
+
+        rendered = render_template(
+            orchestrate_skill.instructions,
+            {
+                "data_domains": simplify_data_domains(data_domains),
+                "current_filters": _format_current_filters(current_filters),
+            },
+        )
+        retry_msgs = normalize_tool_calls(copy.deepcopy(messages))
+        retry_msgs.insert(0, {"role": "system", "content": rendered})
+        hint = "The previous tool call had errors:\n" + "\n".join(
+            f"- {e}" for e in errors
+        )
+        retry_msgs.append(
+            {
+                "role": "assistant",
+                "content": f"Tool call: FilterData({json.dumps(prev_tool_args)})",
+            }
+        )
+        retry_msgs.append(
+            {
+                "role": "user",
+                "content": hint
+                + "\n\nReturn a corrected FilterData call. Pick 'add', 'modify', or 'remove' according to the Current Filters list.",
+            }
+        )
+
+        gpt_client = self.agent._get_gpt_client(openai_api_key)
+        try:
+            resp = gpt_client.chat.completions.create(
+                model=self.agent.gpt_model_name,
+                messages=retry_msgs,
+                tools=[filter_tool],
+                tool_choice={
+                    "type": "function",
+                    "function": {"name": "FilterData"},
+                },
+                temperature=0.0,
+                max_completion_tokens=1024,
+            )
+            tc = resp.choices[0].message.tool_calls[0]
+            return json.loads(tc.function.arguments)
+        except Exception as exc:
+            logger.warning("FilterData retry failed: %s", exc)
+            return None
 
     # ------------------------------------------------------------------
     # Core orchestration logic
@@ -314,6 +512,7 @@ class Orchestrator:
         messages,
         data_schema,
         data_domains,
+        current_filters=None,
         openai_api_key=None,
     ):
         msgs = normalize_tool_calls(copy.deepcopy(messages))
@@ -321,7 +520,10 @@ class Orchestrator:
         orchestrate_skill = self.skills["orchestrate"]
         rendered = render_template(
             orchestrate_skill.instructions,
-            {"data_domains": simplify_data_domains(data_domains)},
+            {
+                "data_domains": simplify_data_domains(data_domains),
+                "current_filters": _format_current_filters(current_filters or []),
+            },
         )
         msgs.insert(0, {"role": "system", "content": rendered})
 
@@ -363,12 +565,16 @@ class Orchestrator:
                 logger.warning("Unknown tool: %s, skipping", tool_name)
                 continue
 
+            handler_kwargs = {"openai_api_key": openai_api_key}
+            if tool_name == "FilterData":
+                handler_kwargs["current_filters"] = current_filters or []
+
             result = handler(
                 tool_args,
                 messages,
                 data_schema,
                 data_domains,
-                openai_api_key=openai_api_key,
+                **handler_kwargs,
             )
             tool_calls.append(result)
 

--- a/src/udiagent/server/app.py
+++ b/src/udiagent/server/app.py
@@ -111,6 +111,7 @@ def yac_completions(
         messages=request.messages,
         data_schema=request.dataSchema,
         data_domains=request.dataDomains,
+        current_filters=request.currentFilters,
         openai_api_key=x_openai_key,
     )
     logger.info("orchestrator_choice: %s", result.orchestrator_choice)
@@ -128,6 +129,7 @@ def yac_benchmark(
         messages=request.messages,
         data_schema=request.dataSchema,
         data_domains=request.dataDomains,
+        current_filters=request.currentFilters,
         openai_api_key=x_openai_key,
     )
 

--- a/src/udiagent/server/models.py
+++ b/src/udiagent/server/models.py
@@ -1,16 +1,18 @@
 """Pydantic request/response models for the server."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class YACCompletionRequest(BaseModel):
     messages: list[dict]
     dataSchema: str
     dataDomains: str
+    currentFilters: list[dict] = Field(default_factory=list)
 
 
 class YACBenchmarkCompletionRequest(BaseModel):
     messages: list[dict]
     dataSchema: str
     dataDomains: str
+    currentFilters: list[dict] = Field(default_factory=list)
     orchestrator_choice: str | None = None

--- a/src/udiagent/tools.py
+++ b/src/udiagent/tools.py
@@ -166,13 +166,26 @@ ORCHESTRATOR_TOOLS = [
         "function": {
             "name": "FilterData",
             "description": (
-                "Filter the dataset to a subset of rows. Use for categorical filters "
-                "(e.g. filter to Female donors) or numeric range filters (e.g. filter "
-                "to age > 50). Call this tool multiple times for multiple filters."
+                "Add, modify, or remove a filter on the dataset. Use 'add' to "
+                "introduce a new filter, 'modify' to update an existing filter's "
+                "values (same entity/field), and 'remove' to clear an existing "
+                "filter. Filters are identified by their (entity, field) pair — "
+                "only one filter per (entity, field) is allowed; re-filtering an "
+                "already-filtered field must use 'modify'. Call this tool once "
+                "per filter operation."
             ),
             "parameters": {
                 "type": "object",
                 "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["add", "modify", "remove"],
+                        "description": (
+                            "The filter operation: 'add' for a new filter on an "
+                            "unfiltered field, 'modify' to change the values of an "
+                            "existing filter, 'remove' to drop an existing filter."
+                        ),
+                    },
                     "title": {
                         "type": "string",
                         "description": "A short, informative title for the filter (e.g. 'Donor Sex', 'Donor Age', 'Sample Assay Type').",
@@ -188,7 +201,7 @@ ORCHESTRATOR_TOOLS = [
                     "filterType": {
                         "type": "string",
                         "enum": ["point", "interval"],
-                        "description": "Type of filter: 'point' for categorical values, 'interval' for numeric ranges.",
+                        "description": "Type of filter: 'point' for categorical values, 'interval' for numeric ranges. Required for 'add' and 'modify'; may be omitted for 'remove'.",
                     },
                     "intervalRange": {
                         "type": "object",
@@ -207,7 +220,7 @@ ORCHESTRATOR_TOOLS = [
                         "description": "Values to filter for. Required when filterType is 'point'.",
                     },
                 },
-                "required": ["entity", "field", "filterType"],
+                "required": ["action", "entity", "field"],
                 "additionalProperties": False,
             },
         },

--- a/tests/test_filter_management.py
+++ b/tests/test_filter_management.py
@@ -1,0 +1,269 @@
+"""Tests for action-aware FilterData validation, retry, and payload shape."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from udiagent.orchestrator import (
+    Orchestrator,
+    _build_filter_payload,
+    _format_current_filters,
+    _validate_filter_action,
+)
+
+
+PENGUIN_SCHEMA = {
+    "resources": [
+        {
+            "name": "penguins",
+            "schema": {
+                "fields": [
+                    {"name": "sex", "udi:data_type": "nominal"},
+                    {"name": "species", "udi:data_type": "nominal"},
+                    {"name": "body_mass_g", "udi:data_type": "quantitative"},
+                ]
+            },
+        }
+    ]
+}
+
+SCHEMA_KEYS = {
+    ("penguins", "sex"),
+    ("penguins", "species"),
+    ("penguins", "body_mass_g"),
+}
+
+
+def _existing_filter(entity, field, ftype="point", values=None, rng=None):
+    filt = {"filterType": ftype}
+    if ftype == "point":
+        filt["pointValues"] = values or ["Male"]
+    else:
+        filt["intervalRange"] = rng or {"min": 0, "max": 1}
+    return {"entity": entity, "field": field, "filter": filt}
+
+
+class TestValidate:
+    def test_add_new_field_passes(self):
+        args = {
+            "action": "add",
+            "entity": "penguins",
+            "field": "sex",
+            "filterType": "point",
+            "pointValues": ["Male"],
+        }
+        assert _validate_filter_action(args, SCHEMA_KEYS, []) == []
+
+    def test_add_already_filtered_is_rejected(self):
+        args = {
+            "action": "add",
+            "entity": "penguins",
+            "field": "sex",
+            "filterType": "point",
+            "pointValues": ["Male"],
+        }
+        current = [_existing_filter("penguins", "sex")]
+        errors = _validate_filter_action(args, SCHEMA_KEYS, current)
+        assert any("already exists" in e for e in errors)
+
+    def test_modify_requires_existing_filter(self):
+        args = {
+            "action": "modify",
+            "entity": "penguins",
+            "field": "sex",
+            "filterType": "point",
+            "pointValues": ["Female"],
+        }
+        errors = _validate_filter_action(args, SCHEMA_KEYS, [])
+        assert any("No existing filter" in e for e in errors)
+
+    def test_modify_on_existing_passes(self):
+        args = {
+            "action": "modify",
+            "entity": "penguins",
+            "field": "sex",
+            "filterType": "point",
+            "pointValues": ["Female"],
+        }
+        current = [_existing_filter("penguins", "sex")]
+        assert _validate_filter_action(args, SCHEMA_KEYS, current) == []
+
+    def test_remove_requires_existing_filter(self):
+        args = {"action": "remove", "entity": "penguins", "field": "sex"}
+        errors = _validate_filter_action(args, SCHEMA_KEYS, [])
+        assert any("No existing filter" in e for e in errors)
+
+    def test_remove_on_existing_passes_without_filter_type(self):
+        args = {"action": "remove", "entity": "penguins", "field": "sex"}
+        current = [_existing_filter("penguins", "sex")]
+        assert _validate_filter_action(args, SCHEMA_KEYS, current) == []
+
+    def test_unknown_entity_field_is_rejected(self):
+        args = {
+            "action": "add",
+            "entity": "penguins",
+            "field": "wingspan",
+            "filterType": "point",
+            "pointValues": ["big"],
+        }
+        errors = _validate_filter_action(args, SCHEMA_KEYS, [])
+        assert any("not a valid" in e for e in errors)
+
+    def test_point_action_requires_values(self):
+        args = {
+            "action": "add",
+            "entity": "penguins",
+            "field": "sex",
+            "filterType": "point",
+            "pointValues": [],
+        }
+        errors = _validate_filter_action(args, SCHEMA_KEYS, [])
+        assert any("pointValues" in e for e in errors)
+
+
+class TestPayloadShape:
+    def test_remove_payload_omits_filter(self):
+        args = {"action": "remove", "entity": "penguins", "field": "sex"}
+        payload = _build_filter_payload(args, validation_retries=0)
+        assert payload["action"] == "remove"
+        assert "filter" not in payload
+        assert payload["validation_retries"] == 0
+
+    def test_add_payload_includes_filter(self):
+        args = {
+            "action": "add",
+            "entity": "penguins",
+            "field": "sex",
+            "filterType": "point",
+            "pointValues": ["Male"],
+        }
+        payload = _build_filter_payload(args, validation_retries=0)
+        assert payload["filter"]["filterType"] == "point"
+        assert payload["filter"]["pointValues"] == ["Male"]
+
+
+class TestFormatCurrentFilters:
+    def test_empty_returns_none_marker(self):
+        assert "none" in _format_current_filters([]).lower()
+
+    def test_renders_each_filter(self):
+        current = [
+            _existing_filter("penguins", "sex", "point", ["Male"]),
+            _existing_filter(
+                "penguins",
+                "body_mass_g",
+                "interval",
+                rng={"min": 3000, "max": 4500},
+            ),
+        ]
+        rendered = _format_current_filters(current)
+        assert "entity=penguins, field=sex" in rendered
+        assert "entity=penguins, field=body_mass_g" in rendered
+        assert "range [3000, 4500]" in rendered
+
+
+class TestHandlerRetry:
+    def _make_orchestrator(self):
+        from udiagent.agent import UDIAgent
+        from udiagent.skills import load_skills
+        from udiagent.tools import ORCHESTRATOR_TOOLS
+
+        agent = UDIAgent.__new__(UDIAgent)
+        agent.gpt_model = MagicMock(name="default_gpt_model")
+        agent.gpt_model_name = "gpt-4.1"
+        agent._get_gpt_client = MagicMock(return_value=agent.gpt_model)
+        orch = Orchestrator.__new__(Orchestrator)
+        orch.agent = agent
+        orch.skills = load_skills()
+        orch.tools = ORCHESTRATOR_TOOLS
+        return orch, agent
+
+    def test_add_on_existing_filter_triggers_retry_to_modify(self):
+        orch, agent = self._make_orchestrator()
+
+        corrected_args = {
+            "action": "modify",
+            "entity": "penguins",
+            "field": "sex",
+            "filterType": "point",
+            "pointValues": ["Female"],
+        }
+        response = MagicMock()
+        response.choices = [
+            MagicMock(
+                message=MagicMock(
+                    tool_calls=[
+                        MagicMock(
+                            function=MagicMock(
+                                arguments=json.dumps(corrected_args)
+                            )
+                        )
+                    ]
+                )
+            )
+        ]
+        agent.gpt_model.chat.completions.create = MagicMock(return_value=response)
+
+        initial_args = {
+            "action": "add",
+            "entity": "penguins",
+            "field": "sex",
+            "filterType": "point",
+            "pointValues": ["Female"],
+        }
+        result = orch._handle_filter_data(
+            initial_args,
+            messages=[{"role": "user", "content": "filter to females"}],
+            data_schema=json.dumps(PENGUIN_SCHEMA),
+            data_domains="[]",
+            current_filters=[_existing_filter("penguins", "sex")],
+            openai_api_key=None,
+        )
+
+        args = result["arguments"]
+        assert args["action"] == "modify"
+        assert args["validation_retries"] == 1
+        assert args["filter"]["pointValues"] == ["Female"]
+
+    def test_valid_add_does_not_retry(self):
+        orch, agent = self._make_orchestrator()
+        agent.gpt_model.chat.completions.create = MagicMock(
+            side_effect=AssertionError("retry should not be invoked")
+        )
+
+        args = {
+            "action": "add",
+            "entity": "penguins",
+            "field": "sex",
+            "filterType": "point",
+            "pointValues": ["Male"],
+        }
+        result = orch._handle_filter_data(
+            args,
+            messages=[],
+            data_schema=json.dumps(PENGUIN_SCHEMA),
+            data_domains="[]",
+            current_filters=[],
+            openai_api_key=None,
+        )
+        assert result["arguments"]["action"] == "add"
+        assert result["arguments"]["validation_retries"] == 0
+
+    def test_remove_on_existing_passes(self):
+        orch, agent = self._make_orchestrator()
+        agent.gpt_model.chat.completions.create = MagicMock(
+            side_effect=AssertionError("retry should not be invoked")
+        )
+
+        args = {"action": "remove", "entity": "penguins", "field": "sex"}
+        result = orch._handle_filter_data(
+            args,
+            messages=[],
+            data_schema=json.dumps(PENGUIN_SCHEMA),
+            data_domains="[]",
+            current_filters=[_existing_filter("penguins", "sex")],
+            openai_api_key=None,
+        )
+        assert result["arguments"]["action"] == "remove"
+        assert "filter" not in result["arguments"]


### PR DESCRIPTION
## Summary
- Filters are now explicitly threaded through the request instead of being inferred from conversation history. The server accepts a ``currentFilters`` list and ``Orchestrator.run`` forwards it into the orchestrate prompt and the filter handler.
- ``FilterData`` gains a required ``action`` discriminator: ``add``, ``modify``, or ``remove``. Filters are identified by their ``(entity, field)`` pair (per spec author's choice); re-filtering an already-filtered field must use ``modify``, not ``add``.
- The filter handler validates each call against the schema and current filters and retries once via a focused LLM call when validation fails, mirroring the visualization generator's retry pattern. ``validation_retries`` is surfaced on the tool-call result.
- The outgoing filter payload now carries ``action``; ``intervalRange``/``pointValues`` are omitted for ``remove``.

## Changes
- ``src/udiagent/tools.py`` — ``FilterData`` gains ``action`` (enum), relaxes required fields so ``remove`` can carry only ``(entity, field)``.
- ``src/udiagent/orchestrator.py``
  - ``Orchestrator.run`` accepts ``current_filters``.
  - ``_orchestrate_tool_calls`` renders a ``Current Filters`` block into the prompt.
  - New helpers: ``_build_schema_field_meta``, ``_format_current_filters``, ``_validate_filter_action``, ``_build_filter_payload``.
  - ``_handle_filter_data`` validates the tool call against schema + current filters; ``_retry_filter_data`` performs the focused retry on failure.
- ``src/udiagent/data/skills/orchestrate.md`` — new ``Filter Management`` section explains ``action``; new ``Current Filters`` block.
- ``src/udiagent/server/models.py`` + ``src/udiagent/server/app.py`` — request models accept ``currentFilters``, endpoints thread it through.
- ``src/udiagent/benchmark/runner.py`` — ``check_filter_rubric`` scores ``action`` and short-circuits filter-type/value checks for ``remove``.
- ``tests/test_filter_management.py`` — 15 new unit tests for validation rules, payload shape, filter rendering, and the retry flow.

## Spec
``.claude/todo/done/improve-agent-filter-management.md`` (archived after merge). Design choices per spec author: identify filters by ``(entity, field)`` tuple; use ``action`` discriminator on a single tool rather than sibling tools; reuse the orchestrate prompt for generation rather than adding separate ``filter_generate.md`` / ``filter_validate.md`` skill files (the tool schema and retry prompt carry the semantics without the extra indirection).

## Frontend coordination
``NickAkhmetov/udi-chat-react`` must be updated in lockstep to:
1. Send ``currentFilters`` on each request.
2. Read the new ``action`` field on FilterData tool calls and apply add/modify/remove accordingly.
3. Handle ``action=remove`` payloads that omit ``filter``.

## Test plan
- [x] ``uv run pytest tests/`` — 21 passed (15 new).
- [ ] Manual: start with no filters, apply a filter, then ask to change its values → expect ``action=modify``.
- [ ] Manual: ask to clear a filter → expect ``action=remove`` with no ``filter`` payload.
- [ ] Manual: intentionally prompt an ``add`` on an already-filtered field and confirm ``validation_retries=1`` with corrected ``action=modify``.
- [ ] Benchmark: run existing benchmarks to confirm they still pass (action defaults to ``add`` for fixtures without an explicit action).

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)