### PR TITLE
Rescale histogram y-axis on filter

### DIFF
--- a/scripts/template_viz_generation.py
+++ b/scripts/template_viz_generation.py
@@ -1294,7 +1294,7 @@ def generate():
             .mark("rect")
             .x(field="start", type="quantitative", title="<F>")
             .x2(field="end", type="quantitative")
-            .y(field="count", type="quantitative")
+            .y(field="count", type="quantitative", domainWhenFiltered="filtered")
         ),
         chart_type=ChartType.HISTOGRAM,
         task_types=[

--- a/src/udiagent/data/skills/template_visualizations.json
+++ b/src/udiagent/data/skills/template_visualizations.json
@@ -762,7 +762,7 @@
       "What is the distribution of <F:q>?",
       "Make a histogram of <F:q>?"
     ],
-    "spec_template":"{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['<F>'] != null\"}, {\"binby\": {\"field\": \"<F>\", \"output\": {\"bin_start\": \"start\", \"bin_end\": \"end\"}}}, {\"rollup\": {\"count\": {\"op\": \"count\"}}}], \"representation\": {\"mark\": \"rect\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"start\", \"type\": \"quantitative\", \"title\": \"<F>\"}, {\"encoding\": \"x2\", \"field\": \"end\", \"type\": \"quantitative\"}, {\"encoding\": \"y\", \"field\": \"count\", \"type\": \"quantitative\"}]}}",
+    "spec_template":"{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['<F>'] != null\"}, {\"binby\": {\"field\": \"<F>\", \"output\": {\"bin_start\": \"start\", \"bin_end\": \"end\"}}}, {\"rollup\": {\"count\": {\"op\": \"count\"}}}], \"representation\": {\"mark\": \"rect\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"start\", \"type\": \"quantitative\", \"title\": \"<F>\"}, {\"encoding\": \"x2\", \"field\": \"end\", \"type\": \"quantitative\"}, {\"encoding\": \"y\", \"field\": \"count\", \"type\": \"quantitative\", \"domainWhenFiltered\": \"filtered\"}]}}",
     "creation_method":"template",
     "chart_type":"histogram",
     "chart_complexity":"medium",

--- a/src/udiagent/generated_vis_tools.py
+++ b/src/udiagent/generated_vis_tools.py
@@ -602,7 +602,7 @@ TEMPLATES = ['{"source": {"name": "<E>", "source": "<E.url>"}, "transformation":
  '{"field": "<F>", "output": {"bin_start": "start", "bin_end": "end"}}}, {"rollup": {"count": {"op": "count"}}}], '
  '"representation": {"mark": "rect", "mapping": [{"encoding": "x", "field": "start", "type": "quantitative", "title": '
  '"<F>"}, {"encoding": "x2", "field": "end", "type": "quantitative"}, {"encoding": "y", "field": "count", "type": '
- '"quantitative"}]}}',
+ '"quantitative", "domainWhenFiltered": "filtered"}]}}',
  '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'<F>\'] != null"}, {"kde": '
  '{"field": "<F>", "output": {"sample": "<F>", "density": "density"}}}], "representation": {"mark": "area", "mapping": '
  '[{"encoding": "x", "field": "<F>", "type": "quantitative"}, {"encoding": "y", "field": "density", "type": '


### PR DESCRIPTION
## Summary
- Add ``domainWhenFiltered=\"filtered\"`` to the histogram template's y encoding so the count axis rescales to the filtered data after the user applies a filter, instead of staying pinned to the unfiltered domain (#36).
- The bin-stability issue (#37) is fixed upstream in the ``udi-grammar`` renderer — the frontend PR will pick up the version bump separately. No backend template change needed for bins.

## Changes
- ``scripts/template_viz_generation.py`` — histogram builder at lines 1288-1306: y encoding gains ``domainWhenFiltered=\"filtered\"``, mirroring the KDE area chart pattern at line 1327.
- ``src/udiagent/data/skills/template_visualizations.json`` — regenerated histogram ``spec_template`` now carries the new y-axis attribute.
- ``src/udiagent/generated_vis_tools.py`` — regenerated. The histogram template string in ``TEMPLATES`` includes ``\"domainWhenFiltered\": \"filtered\"`` on the y encoding (verified at line 605).

## Spec
``.claude/todo/done/fix-histogram-filter-scaling.md`` (archived after merge). Per spec author's annotations: skip the ``udi-grammar`` / ``udi-grammar-py`` bump in this PR — the frontend handles the grammar update separately.

## Frontend coordination
``NickAkhmetov/udi-chat-react`` needs to render against the ``udi-grammar`` version that ships the bin-stability fix for #37 to fully land. Link that PR here once it's open.

## Test plan
- [x] ``uv run pytest tests/`` — 6 passed.
- [x] Confirmed the regenerated ``generated_vis_tools.py`` is byte-identical to a clean regeneration from the updated JSON (deterministic output).
- [ ] Manual: start the server, produce a histogram, apply a filter, confirm the y-axis rescales to the filtered counts.
- [ ] Manual (post-frontend-bump): apply and toggle a filter on a histogram, confirm bin edges remain stable.

Closes #36
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)