### PR TITLE
Add a data-cube visualization template set to YAC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,4 +153,7 @@ data_collection/old*
 data_collection/data_untill_1112
 data_collection/data_tmp
 
+# Raw data-cube fixtures are kept locally, not committed
+data/example_data_cube/
+
 .DS_Store

--- a/data/data_domains/encounter_cube_domains.json
+++ b/data/data_domains/encounter_cube_domains.json
@@ -1,0 +1,86 @@
+[
+  {
+    "entity": "encounter_counts",
+    "field": "cnt",
+    "type": "interval",
+    "fieldDescription": "A count of encounter records matching the dimension values on the row (a pre-aggregated measure).",
+    "domain": {
+      "min": 10,
+      "max": 109745
+    }
+  },
+  {
+    "entity": "encounter_counts",
+    "field": "period_start_month",
+    "type": "interval",
+    "fieldDescription": "The month in which the encounter began (derived from Encounter.period).",
+    "domain": {
+      "min": "1/1/1932",
+      "max": "4/1/2023"
+    }
+  },
+  {
+    "entity": "encounter_counts",
+    "field": "class_display",
+    "type": "point",
+    "fieldDescription": "The context in which the encounter occurred (e.g. ambulatory, emergency, inpatient).",
+    "domain": {
+      "values": [
+        "ambulatory",
+        "emergency",
+        "home health",
+        "inpatient encounter",
+        "virtual"
+      ]
+    }
+  },
+  {
+    "entity": "encounter_counts",
+    "field": "age_at_visit",
+    "type": "interval",
+    "fieldDescription": "The patient's age in years at the time of the encounter.",
+    "domain": {
+      "min": 0,
+      "max": 96
+    }
+  },
+  {
+    "entity": "encounter_counts",
+    "field": "gender",
+    "type": "point",
+    "fieldDescription": "The patient's administrative gender.",
+    "domain": {
+      "values": [
+        "female",
+        "male"
+      ]
+    }
+  },
+  {
+    "entity": "encounter_counts",
+    "field": "race_display",
+    "type": "point",
+    "fieldDescription": "The patient's race.",
+    "domain": {
+      "values": [
+        "asian",
+        "black or african american",
+        "native hawaiian or other pacific islander",
+        "unknown",
+        "white"
+      ]
+    }
+  },
+  {
+    "entity": "encounter_counts",
+    "field": "ethnicity_display",
+    "type": "point",
+    "fieldDescription": "The patient's ethnicity.",
+    "domain": {
+      "values": [
+        "hispanic or latino",
+        "not hispanic or latino"
+      ]
+    }
+  }
+]

--- a/data/data_domains/encounter_cube_schema.json
+++ b/data/data_domains/encounter_cube_schema.json
@@ -1,0 +1,99 @@
+{
+  "name": "encounter_counts",
+  "resources": [
+    {
+      "name": "encounter_counts",
+      "type": "table",
+      "path": "core__count_encounter_month.csv",
+      "scheme": "file",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "encoding": "utf-8",
+      "schema": {
+        "fields": [
+          {
+            "name": "cnt",
+            "type": "number",
+            "description": "A count of encounter records matching the dimension values on the row (a pre-aggregated measure).",
+            "udi:cardinality": 1327,
+            "udi:unique": false,
+            "udi:data_type": "quantitative",
+            "udi:overlapping_fields": "all"
+          },
+          {
+            "name": "period_start_month",
+            "type": "string",
+            "description": "The month in which the encounter began (derived from Encounter.period).",
+            "udi:cardinality": 881,
+            "udi:unique": false,
+            "udi:data_type": "temporal",
+            "udi:overlapping_fields": "all"
+          },
+          {
+            "name": "class_display",
+            "type": "string",
+            "description": "The context in which the encounter occurred (e.g. ambulatory, emergency, inpatient).",
+            "udi:cardinality": 5,
+            "udi:unique": false,
+            "udi:data_type": "nominal",
+            "udi:overlapping_fields": "all"
+          },
+          {
+            "name": "age_at_visit",
+            "type": "number",
+            "description": "The patient's age in years at the time of the encounter.",
+            "udi:cardinality": 97,
+            "udi:unique": false,
+            "udi:data_type": "quantitative",
+            "udi:overlapping_fields": "all"
+          },
+          {
+            "name": "gender",
+            "type": "string",
+            "description": "The patient's administrative gender.",
+            "udi:cardinality": 2,
+            "udi:unique": false,
+            "udi:data_type": "nominal",
+            "udi:overlapping_fields": "all"
+          },
+          {
+            "name": "race_display",
+            "type": "string",
+            "description": "The patient's race.",
+            "udi:cardinality": 5,
+            "udi:unique": false,
+            "udi:data_type": "nominal",
+            "udi:overlapping_fields": "all"
+          },
+          {
+            "name": "ethnicity_display",
+            "type": "string",
+            "description": "The patient's ethnicity.",
+            "udi:cardinality": 2,
+            "udi:unique": false,
+            "udi:data_type": "nominal",
+            "udi:overlapping_fields": "all"
+          }
+        ],
+        "primaryKey": [],
+        "foreignKeys": []
+      },
+      "udi:row_count": 25202,
+      "udi:column_count": 7,
+      "udi:cube": true,
+      "udi:measures": [
+        "cnt"
+      ],
+      "udi:dimensions": [
+        "period_start_month",
+        "class_display",
+        "age_at_visit",
+        "gender",
+        "race_display",
+        "ethnicity_display"
+      ]
+    }
+  ],
+  "udi:name": "encounter_counts",
+  "udi:path": "./data/example_data_cube/"
+}

--- a/scripts/regenerate_vis_tools.py
+++ b/scripts/regenerate_vis_tools.py
@@ -2,8 +2,12 @@
 Regenerate template visualizations and typed tool definitions in one step.
 
 Usage:
+    # Line-item set (default)
     python scripts/regenerate_vis_tools.py
     python scripts/regenerate_vis_tools.py --schema data/data_domains/hubmap_data_schema.json
+
+    # Data-cube set
+    python scripts/regenerate_vis_tools.py --template-set cube
 """
 
 import argparse
@@ -12,9 +16,25 @@ import sys
 from pathlib import Path
 
 _repo_root = Path(__file__).resolve().parent.parent
-_default_templates = _repo_root / "src" / "skills" / "template_visualizations.json"
-_default_schema = _repo_root / "data" / "data_domains" / "hubmap_data_schema.json"
-_default_tools_output = _repo_root / "src" / "generated_vis_tools.py"
+_pkg_skills = _repo_root / "src" / "udiagent" / "data" / "skills"
+_generate_tools = _repo_root / "src" / "udiagent" / "generate_tools.py"
+
+# Per-template-set defaults: which generator builds the templates, where the
+# templates and generated tools live, and the schema they are typed against.
+_TEMPLATE_SETS = {
+    "line_item": {
+        "generator": _repo_root / "scripts" / "template_viz_generation.py",
+        "templates": _pkg_skills / "template_visualizations.json",
+        "schema": _repo_root / "data" / "data_domains" / "hubmap_data_schema.json",
+        "tools": _repo_root / "src" / "udiagent" / "generated_vis_tools.py",
+    },
+    "cube": {
+        "generator": _repo_root / "scripts" / "template_viz_generation_cube.py",
+        "templates": _pkg_skills / "template_visualizations_cube.json",
+        "schema": _repo_root / "data" / "data_domains" / "encounter_cube_schema.json",
+        "tools": _repo_root / "src" / "udiagent" / "generated_vis_tools_cube.py",
+    },
+}
 
 
 def main():
@@ -22,37 +42,48 @@ def main():
         description="Regenerate template visualizations and typed tool definitions.",
     )
     parser.add_argument(
+        "--template-set",
+        choices=sorted(_TEMPLATE_SETS),
+        default="line_item",
+        help="Which template set to regenerate (default: line_item).",
+    )
+    parser.add_argument(
         "--schema",
         type=str,
-        default=str(_default_schema),
-        help="Path to data schema JSON (default: data/data_domains/hubmap_data_schema.json)",
+        default=None,
+        help="Path to data schema JSON (default: the schema for the chosen template set).",
     )
     parser.add_argument(
         "--templates-output",
         type=str,
-        default=str(_default_templates),
-        help="Output path for template visualizations JSON",
+        default=None,
+        help="Output path for template visualizations JSON.",
     )
     parser.add_argument(
         "--tools-output",
         type=str,
-        default=str(_default_tools_output),
-        help="Output path for generated_vis_tools.py",
+        default=None,
+        help="Output path for the generated tools module.",
     )
     args = parser.parse_args()
 
+    cfg = _TEMPLATE_SETS[args.template_set]
+    schema = args.schema or str(cfg["schema"])
+    templates_output = args.templates_output or str(cfg["templates"])
+    tools_output = args.tools_output or str(cfg["tools"])
+
     # Step 1: Generate template visualizations
-    print("=== Step 1: Generating template visualizations ===")
+    print(f"=== Step 1: Generating '{args.template_set}' template visualizations ===")
     result = subprocess.run(
         [
             sys.executable,
-            str(_repo_root / "scripts" / "template_viz_generation.py"),
-            "-o", args.templates_output,
+            str(cfg["generator"]),
+            "-o", templates_output,
         ],
         cwd=str(_repo_root),
     )
     if result.returncode != 0:
-        print("ERROR: template_viz_generation.py failed", file=sys.stderr)
+        print("ERROR: template generation failed", file=sys.stderr)
         sys.exit(1)
 
     # Step 2: Generate typed tool definitions
@@ -60,10 +91,10 @@ def main():
     result = subprocess.run(
         [
             sys.executable,
-            str(_repo_root / "src" / "generate_tools.py"),
-            "--templates", args.templates_output,
-            "--schema", args.schema,
-            "--output", args.tools_output,
+            str(_generate_tools),
+            "--templates", templates_output,
+            "--schema", schema,
+            "--output", tools_output,
         ],
         cwd=str(_repo_root),
     )

--- a/scripts/template_viz_generation.py
+++ b/scripts/template_viz_generation.py
@@ -1514,7 +1514,16 @@ def generate():
 
 
 if __name__ == "__main__":
+    import argparse
     import os
+
+    parser = argparse.ArgumentParser(description="Generate line-item visualization templates.")
+    parser.add_argument(
+        "-o", "--output",
+        default="./src/skills/template_visualizations.json",
+        help="Output template JSON path.",
+    )
+    args = parser.parse_args()
 
     os.makedirs("./out", exist_ok=True)
     df = generate()
@@ -1527,5 +1536,5 @@ if __name__ == "__main__":
     print(f"\nChart types: {df['chart_type'].value_counts().to_dict()}")
     print(f"Complexity: {df['chart_complexity'].value_counts().to_dict()}")
 
-    df.to_json("./src/skills/template_visualizations.json", orient="records", indent=2)
-    print(f"\nExported to ./src/skills/template_visualizations.json")
+    df.to_json(args.output, orient="records", indent=2)
+    print(f"\nExported to {args.output}")

--- a/scripts/template_viz_generation_cube.py
+++ b/scripts/template_viz_generation_cube.py
@@ -1,0 +1,588 @@
+"""Generate the *data-cube* template visualization set.
+
+Unlike ``template_viz_generation.py`` (which targets tidy, line-item tables and
+re-aggregates with groupby/rollup/count), this generator targets a **pre-aggregated
+powerset cube**: one measure column (e.g. ``cnt``) plus several dimension columns,
+where every row is a marginal/crosstab and *empty* dimension columns mean the row is
+aggregated over that dimension.
+
+The core idea: to read the count for a set of "active" dimensions, you do NOT
+re-aggregate. You **filter to the marginal rows** — the active dimensions non-null and
+every other dimension null — then map the measure directly. Proportional charts do this
+marginal filter first, then compute proportions on top.
+
+Chart types that require per-record data (scatterplot, grouped_scatter, dot,
+grouped_dot, histogram, CDF/KDE/density) are impossible on a cube and are omitted.
+
+Specs are emitted as plain dicts (no ``udi_grammar_py`` dependency) and every spec is
+validated against ``UDIGrammarSchema.json`` before being written.
+
+Usage:
+    python scripts/template_viz_generation_cube.py \
+        --schema data/data_domains/encounter_cube_schema.json \
+        -o src/udiagent/data/skills/template_visualizations_cube.json
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import jsonschema
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_SCHEMA = _REPO_ROOT / "data" / "data_domains" / "encounter_cube_schema.json"
+_DEFAULT_OUT = (
+    _REPO_ROOT / "src" / "udiagent" / "data" / "skills" / "template_visualizations_cube.json"
+)
+_GRAMMAR = _REPO_ROOT / "src" / "udiagent" / "data" / "UDIGrammarSchema.json"
+
+
+# ---------------------------------------------------------------------------
+# Cube description (loaded from the UDI schema)
+# ---------------------------------------------------------------------------
+
+
+def load_cube(schema_path):
+    """Read measure, dimensions and per-field metadata from a UDI cube schema."""
+    raw = json.loads(Path(schema_path).read_text())
+    resource = raw["resources"][0]
+    fields = {f["name"]: f for f in resource["schema"]["fields"]}
+    measures = resource.get("udi:measures")
+    dims = resource.get("udi:dimensions")
+    if not measures or not dims:
+        # Fall back: a single quantitative field is the measure, the rest are dims.
+        measures = [n for n, f in fields.items() if f.get("udi:data_type") == "quantitative"][:1]
+        dims = [n for n in fields if n not in measures]
+    return {
+        "entity": resource["name"],
+        "measure": measures[0],
+        "dims": list(dims),
+        "fields": fields,
+    }
+
+
+# Human-friendly names for query templates / descriptions.
+DISPLAY = {
+    "cnt": "encounter count",
+    "period_start_month": "month",
+    "class_display": "encounter class",
+    "age_at_visit": "age",
+    "gender": "gender",
+    "race_display": "race",
+    "ethnicity_display": "ethnicity",
+}
+
+
+def display(field):
+    return DISPLAY.get(field, field.replace("_", " "))
+
+
+# ---------------------------------------------------------------------------
+# Spec building blocks
+# ---------------------------------------------------------------------------
+
+
+def source(cube):
+    return {"name": "<E>", "source": "<E.url>"}
+
+
+def marginal_filter(cube, active):
+    """Filter expression selecting the marginal rows for the *active* dimensions.
+
+    Active dimensions must be non-null and every other dimension null, which uniquely
+    selects the pre-aggregated rows at that grouping level in a powerset cube.
+    """
+    active = list(active)
+    parts = []
+    for d in cube["dims"]:
+        if d in active:
+            parts.append(f"d['{d}'] != null")
+        else:
+            parts.append(f"d['{d}'] == null")
+    return " && ".join(parts)
+
+
+def enc_type(cube, field):
+    """Map a cube field's data type to a UDI grammar encoding type.
+
+    The grammar only allows quantitative / ordinal / nominal, so temporal
+    dimensions are encoded as ordinal (ordered categories).
+    """
+    dt = cube["fields"].get(field, {}).get("udi:data_type", "nominal")
+    if dt == "quantitative":
+        return "quantitative"
+    if dt == "temporal":
+        return "ordinal"
+    return "nominal"
+
+
+def data_type(cube, field):
+    """Return the cube field's declared udi:data_type (quantitative/temporal/nominal/ordinal)."""
+    return cube["fields"].get(field, {}).get("udi:data_type", "nominal")
+
+
+def cardinality(cube, field):
+    return cube["fields"].get(field, {}).get("udi:cardinality", 0)
+
+
+# ---------------------------------------------------------------------------
+# Complexity + row assembly (mirrors template_viz_generation.py conventions)
+# ---------------------------------------------------------------------------
+
+
+def _key_count(node):
+    if isinstance(node, dict):
+        return sum(_key_count(v) for v in node.values())
+    if isinstance(node, list):
+        return sum(_key_count(v) for v in node)
+    return 1
+
+
+def make_row(query_templates, spec, chart_type, task_types, description,
+             design_considerations, tasks):
+    n = _key_count(spec)
+    if n <= 12:
+        complexity = "simple"
+    elif n <= 24:
+        complexity = "medium"
+    elif n <= 36:
+        complexity = "complex"
+    else:
+        complexity = "extra complex"
+    return {
+        "query_templates": query_templates,
+        "spec_template": json.dumps(spec),
+        "creation_method": "template",
+        "chart_type": chart_type,
+        "chart_complexity": complexity,
+        "spec_key_count": n,
+        "task_types": task_types,
+        "description": description,
+        "design_considerations": design_considerations,
+        "tasks": tasks,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Template families
+# ---------------------------------------------------------------------------
+
+
+def bar_by_dim(cube, dim):
+    """Bar chart of the measure by a single dimension (its L1 marginal)."""
+    dtype = enc_type(cube, dim)
+    horizontal = dtype == "nominal" and cardinality(cube, dim) > 4
+    dim_enc = {"encoding": "y" if horizontal else "x", "field": dim, "type": dtype}
+    meas_enc = {
+        "encoding": "x" if horizontal else "y",
+        "field": cube["measure"],
+        "type": "quantitative",
+    }
+    spec = {
+        "source": source(cube),
+        "transformation": [{"filter": marginal_filter(cube, [dim])}],
+        "representation": {"mark": "bar", "mapping": [dim_enc, meas_enc]},
+    }
+    orient = "horizontal" if horizontal else "vertical"
+    return make_row(
+        query_templates=[
+            f"How many encounters are there by {display(dim)}?",
+            f"Make a bar chart of {display(cube['measure'])} by {display(dim)}.",
+        ],
+        spec=spec,
+        chart_type="barchart",
+        task_types=["Compute_Derived_Value", "Determine_Range"],
+        description=(
+            f"Shows the pre-aggregated {display(cube['measure'])} for each "
+            f"{display(dim)} as a {orient} bar chart."
+        ),
+        design_considerations=(
+            f"Reads the cube's {display(dim)} marginal by filtering to rows where "
+            f"{dim} is present and all other dimensions are empty; the measure is "
+            f"mapped directly with no re-aggregation. {orient.capitalize()} "
+            f"orientation chosen from category count."
+        ),
+        tasks="Compare counts across categories; identify the most or least common category.",
+    )
+
+
+def line_over_time(cube, dim):
+    """Line chart of the measure over a temporal dimension (its L1 marginal)."""
+    spec = {
+        "source": source(cube),
+        "transformation": [
+            {"filter": marginal_filter(cube, [dim])},
+            {"orderby": {"field": dim, "order": "asc"}},
+        ],
+        "representation": {
+            "mark": "line",
+            "mapping": [
+                {"encoding": "x", "field": dim, "type": enc_type(cube, dim)},
+                {"encoding": "y", "field": cube["measure"], "type": "quantitative"},
+            ],
+        },
+    }
+    return make_row(
+        query_templates=[
+            f"How does the {display(cube['measure'])} change over {display(dim)}?",
+            f"Make a line chart of {display(cube['measure'])} over {display(dim)}.",
+        ],
+        spec=spec,
+        chart_type="line",
+        task_types=["Characterize_Distribution", "Determine_Range"],
+        description=(
+            f"Shows the pre-aggregated {display(cube['measure'])} over "
+            f"{display(dim)} as a line chart."
+        ),
+        design_considerations=(
+            f"Filters to the {display(dim)} marginal (all other dimensions empty), "
+            f"orders the axis ascending, and maps the measure directly. The month is "
+            f"encoded as an ordered (ordinal) axis."
+        ),
+        tasks="Identify trends over time; spot peaks, troughs, and seasonality.",
+    )
+
+
+def circular_by_dim(cube, dim, donut=False):
+    """Pie or donut of the measure by a single dimension (its L1 marginal)."""
+    mapping = [
+        {"encoding": "theta", "field": cube["measure"], "type": "quantitative"},
+        {"encoding": "color", "field": dim, "type": "nominal"},
+    ]
+    rep = {"mark": "arc", "mapping": mapping}
+    if donut:
+        mapping.append({"encoding": "radius", "value": 60})
+        mapping.append({"encoding": "radius2", "value": 80})
+    kind = "donut" if donut else "pie"
+    spec = {
+        "source": source(cube),
+        "transformation": [{"filter": marginal_filter(cube, [dim])}],
+        "representation": rep,
+    }
+    return make_row(
+        query_templates=[f"Make a {kind} chart of {display(cube['measure'])} by {display(dim)}."],
+        spec=spec,
+        chart_type="circular",
+        task_types=["Compute_Derived_Value", "Determine_Range"],
+        description=(
+            f"Shows the proportional {display(cube['measure'])} for each "
+            f"{display(dim)} as a {kind} chart."
+        ),
+        design_considerations=(
+            f"Filters to the {display(dim)} marginal and maps the measure to angle; "
+            f"the renderer normalizes each slice against the total. Suitable for few "
+            f"categories."
+        ),
+        tasks="Assess part-to-whole proportions; identify the dominant category.",
+    )
+
+
+def stacked_bar(cube, axis, sub):
+    """Vertical stacked bar of the measure by two dimensions (their L2 marginal)."""
+    spec = {
+        "source": source(cube),
+        "transformation": [{"filter": marginal_filter(cube, [axis, sub])}],
+        "representation": {
+            "mark": "bar",
+            "mapping": [
+                {"encoding": "x", "field": axis, "type": "nominal"},
+                {"encoding": "y", "field": cube["measure"], "type": "quantitative"},
+                {"encoding": "color", "field": sub, "type": "nominal"},
+            ],
+        },
+    }
+    return make_row(
+        query_templates=[
+            f"How many encounters are there by {display(axis)} and {display(sub)}?",
+            f"Make a stacked bar chart of {display(axis)} and {display(sub)}.",
+        ],
+        spec=spec,
+        chart_type="stacked_bar",
+        task_types=["Compute_Derived_Value"],
+        description=(
+            f"Shows the pre-aggregated {display(cube['measure'])} by {display(axis)} "
+            f"and {display(sub)} as a vertical stacked bar chart."
+        ),
+        design_considerations=(
+            f"Filters to the two-dimension marginal ({axis} and {sub} present, all "
+            f"other dimensions empty) and maps the measure directly. Color encodes the "
+            f"sub-group; prefer the field with fewer categories for color."
+        ),
+        tasks="Compare group compositions across categories; identify dominant sub-groups.",
+    )
+
+
+def grouped_bar(cube, axis, sub):
+    """Grouped (side-by-side) bar of the measure by two dimensions (L2 marginal)."""
+    spec = {
+        "source": source(cube),
+        "transformation": [{"filter": marginal_filter(cube, [axis, sub])}],
+        "representation": {
+            "mark": "bar",
+            "mapping": [
+                {"encoding": "x", "field": axis, "type": "nominal"},
+                {"encoding": "y", "field": cube["measure"], "type": "quantitative"},
+                {"encoding": "xOffset", "field": sub, "type": "nominal"},
+                {"encoding": "color", "field": sub, "type": "nominal"},
+            ],
+        },
+    }
+    return make_row(
+        query_templates=[f"What is the {display(cube['measure'])} of {display(sub)} for each {display(axis)}?"],
+        spec=spec,
+        chart_type="stacked_bar",
+        task_types=["Compute_Derived_Value"],
+        description=(
+            f"Shows the pre-aggregated {display(cube['measure'])} by {display(axis)} "
+            f"and {display(sub)} as a grouped (side-by-side) bar chart."
+        ),
+        design_considerations=(
+            f"Filters to the two-dimension marginal and uses xOffset for side-by-side "
+            f"grouping, enabling direct comparison of {display(sub)} within each "
+            f"{display(axis)}."
+        ),
+        tasks="Directly compare sub-group counts within and across categories.",
+    )
+
+
+def normalized_bar(cube, axis, sub):
+    """Proportional (normalized) stacked bar: marginal filter first, then proportion."""
+    measure = cube["measure"]
+    spec = {
+        "source": source(cube),
+        "transformation": [
+            {"filter": marginal_filter(cube, [axis, sub])},
+            {"groupby": axis, "out": "groupTotals"},
+            {"rollup": {"axis_total": {"op": "sum", "field": measure}}},
+            {"groupby": [sub, axis], "in": "<E>"},
+            {"rollup": {"cell_total": {"op": "sum", "field": measure}}},
+            {"join": {"on": axis}, "in": ["<E>", "groupTotals"], "out": "datasets"},
+            {"derive": {"proportion": "d['cell_total'] / d['axis_total']"}},
+        ],
+        "representation": {
+            "mark": "bar",
+            "mapping": [
+                {"encoding": "x", "field": axis, "type": "nominal"},
+                {"encoding": "y", "field": "proportion", "type": "quantitative"},
+                {"encoding": "color", "field": sub, "type": "nominal"},
+            ],
+        },
+    }
+    return make_row(
+        query_templates=[f"What is the proportion of {display(sub)} for each {display(axis)}?"],
+        spec=spec,
+        chart_type="stacked_bar",
+        task_types=["Compute_Derived_Value"],
+        description=(
+            f"Shows the relative proportion of {display(sub)} within each "
+            f"{display(axis)} as a normalized stacked bar chart."
+        ),
+        design_considerations=(
+            f"First filters to the two-dimension marginal, then sums the measure per "
+            f"{display(axis)} and divides each cell by its group total to obtain "
+            f"proportions. Color is preferably the field with fewer categories."
+        ),
+        tasks="Compare relative proportions across categories; identify dominant sub-groups.",
+    )
+
+
+def heatmap(cube, xdim, ydim):
+    """Heatmap of the measure across two dimensions (their L2 marginal)."""
+    measure = cube["measure"]
+    spec = {
+        "source": source(cube),
+        "transformation": [
+            {"filter": marginal_filter(cube, [xdim, ydim])},
+            {"derive": {"udi_internal_percentile": f"d['{measure}'] / max(d['{measure}'])"}},
+            {"derive": {
+                "udi_internal_text_color_threshold":
+                    "d.udi_internal_percentile > .5 ? 'large' : 'small'"
+            }},
+        ],
+        "representation": [
+            {"mark": "rect", "mapping": [
+                {"encoding": "color", "field": measure, "type": "quantitative"},
+                {"encoding": "y", "field": ydim, "type": "nominal"},
+                {"encoding": "x", "field": xdim, "type": "nominal"},
+            ]},
+            {"mark": "text", "mapping": [
+                {"encoding": "text", "field": measure, "type": "quantitative"},
+                {"encoding": "y", "field": ydim, "type": "nominal"},
+                {"encoding": "x", "field": xdim, "type": "nominal"},
+                {"encoding": "color", "field": "udi_internal_text_color_threshold",
+                 "type": "nominal", "domain": ["large", "small"],
+                 "range": ["white", "black"], "omitLegend": True},
+            ]},
+        ],
+    }
+    return make_row(
+        query_templates=[
+            f"Are there clusters in {display(cube['measure'])} across {display(xdim)} and {display(ydim)}?",
+            f"Make a heatmap of {display(xdim)} and {display(ydim)}.",
+        ],
+        spec=spec,
+        chart_type="heatmap",
+        task_types=["Cluster", "Compute_Derived_Value", "Correlate"],
+        description=(
+            f"Shows the pre-aggregated {display(cube['measure'])} for each combination "
+            f"of {display(xdim)} and {display(ydim)} as a labeled heatmap."
+        ),
+        design_considerations=(
+            f"Filters to the two-dimension marginal and maps the measure to cell color; "
+            f"overlaid text shows exact values with contrast-aware color. The field with "
+            f"more categories is preferably on the y-axis."
+        ),
+        tasks="Identify clusters or patterns across two dimensions; compare counts across combinations.",
+    )
+
+
+def total_table(cube):
+    """Single-row table with the grand total (the all-empty L0 marginal)."""
+    spec = {
+        "source": source(cube),
+        "transformation": [{"filter": marginal_filter(cube, [])}],
+        "representation": {
+            "mark": "row",
+            "mapping": [{"encoding": "text", "field": cube["measure"],
+                         "mark": "text", "type": "nominal"}],
+        },
+    }
+    return make_row(
+        query_templates=[
+            "How many encounters are there in total?",
+            f"What is the total {display(cube['measure'])}?",
+        ],
+        spec=spec,
+        chart_type="table",
+        task_types=["Retrieve_Value", "Compute_Derived_Value"],
+        description=f"Shows the grand-total {display(cube['measure'])} as a single-row table.",
+        design_considerations=(
+            "Reads the grand-total row directly by filtering to the marginal where every "
+            "dimension is empty; no aggregation is performed."
+        ),
+        tasks="Retrieve the overall total.",
+    )
+
+
+def count_table_by_dim(cube, dim):
+    """Table listing each category with its measure and an in-cell bar."""
+    spec = {
+        "source": source(cube),
+        "transformation": [
+            {"filter": marginal_filter(cube, [dim])},
+            {"orderby": {"field": cube["measure"], "order": "desc"}},
+        ],
+        "representation": {
+            "mark": "row",
+            "mapping": [
+                {"encoding": "text", "field": dim, "mark": "text", "type": "nominal"},
+                {"encoding": "x", "field": cube["measure"], "mark": "bar",
+                 "type": "quantitative", "range": {"min": 0.1, "max": 1}},
+            ],
+        },
+    }
+    return make_row(
+        query_templates=[
+            f"List the {display(cube['measure'])} for each {display(dim)}.",
+            f"What is the range of {display(dim)} values?",
+        ],
+        spec=spec,
+        chart_type="table",
+        task_types=["Determine_Range", "Sort", "Retrieve_Value"],
+        description=(
+            f"Lists each {display(dim)} with its pre-aggregated {display(cube['measure'])} "
+            f"as a sorted table with in-cell bars."
+        ),
+        design_considerations=(
+            f"Filters to the {display(dim)} marginal, orders by the measure, and adds "
+            f"in-cell bars for visual comparison."
+        ),
+        tasks="Determine the distinct values of a dimension; compare category counts.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Assembly
+# ---------------------------------------------------------------------------
+
+
+def generate(cube):
+    nominal_dims = [d for d in cube["dims"] if data_type(cube, d) in ("nominal", "ordinal")]
+    temporal_dims = [d for d in cube["dims"] if data_type(cube, d) == "temporal"]
+    quant_dims = [d for d in cube["dims"] if data_type(cube, d) == "quantitative"]
+
+    rows = []
+
+    # Single-dimension bar charts (nominal + quantitative dims).
+    for d in nominal_dims + quant_dims:
+        rows.append(bar_by_dim(cube, d))
+
+    # Line charts over temporal dimensions.
+    for d in temporal_dims:
+        rows.append(line_over_time(cube, d))
+
+    # Pie + donut for a representative low-cardinality nominal dimension.
+    if nominal_dims:
+        rep = nominal_dims[0]
+        rows.append(circular_by_dim(cube, rep, donut=False))
+        rows.append(circular_by_dim(cube, rep, donut=True))
+
+    # Two-dimension charts across representative nominal pairs.
+    pairs = []
+    for i in range(len(nominal_dims)):
+        for j in range(len(nominal_dims)):
+            if i == j:
+                continue
+            pairs.append((nominal_dims[i], nominal_dims[j]))
+    # Keep a representative, bounded set: each axis dim paired with the next one.
+    rep_pairs = []
+    for i in range(len(nominal_dims) - 1):
+        rep_pairs.append((nominal_dims[i], nominal_dims[i + 1]))
+    for axis, sub in rep_pairs:
+        rows.append(stacked_bar(cube, axis, sub))
+        rows.append(grouped_bar(cube, axis, sub))
+        rows.append(normalized_bar(cube, axis, sub))
+        rows.append(heatmap(cube, axis, sub))
+
+    # Tables.
+    rows.append(total_table(cube))
+    for d in nominal_dims:
+        rows.append(count_table_by_dim(cube, d))
+
+    return rows
+
+
+def validate_specs(rows, grammar_path):
+    schema = json.loads(Path(grammar_path).read_text())
+    for i, row in enumerate(rows):
+        spec = json.loads(row["spec_template"])
+        try:
+            jsonschema.validate(instance=spec, schema=schema)
+        except jsonschema.ValidationError as e:
+            raise SystemExit(
+                f"Spec {i} ({row['chart_type']}) failed grammar validation: {e.message}"
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate data-cube visualization templates.")
+    parser.add_argument("--schema", default=str(_DEFAULT_SCHEMA), help="Path to the cube UDI schema JSON.")
+    parser.add_argument("-o", "--output", default=str(_DEFAULT_OUT), help="Output template JSON path.")
+    parser.add_argument("--grammar", default=str(_GRAMMAR), help="Path to UDIGrammarSchema.json.")
+    args = parser.parse_args()
+
+    cube = load_cube(args.schema)
+    rows = generate(cube)
+    validate_specs(rows, args.grammar)
+
+    Path(args.output).write_text(json.dumps(rows, indent=2) + "\n")
+
+    from collections import Counter
+    print(f"Generated {len(rows)} data-cube visualization templates.")
+    print("Chart types:", dict(Counter(r["chart_type"] for r in rows)))
+    print(f"Validated against grammar: {args.grammar}")
+    print(f"Exported to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/udiagent/data/skills/template_visualizations_cube.json
+++ b/src/udiagent/data/skills/template_visualizations_cube.json
@@ -1,0 +1,442 @@
+[
+  {
+    "query_templates": [
+      "How many encounters are there by encounter class?",
+      "Make a bar chart of encounter count by encounter class."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] != null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && d['ethnicity_display'] == null\"}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"y\", \"field\": \"class_display\", \"type\": \"nominal\"}, {\"encoding\": \"x\", \"field\": \"cnt\", \"type\": \"quantitative\"}]}}",
+    "creation_method": "template",
+    "chart_type": "barchart",
+    "chart_complexity": "simple",
+    "spec_key_count": 10,
+    "task_types": [
+      "Compute_Derived_Value",
+      "Determine_Range"
+    ],
+    "description": "Shows the pre-aggregated encounter count for each encounter class as a horizontal bar chart.",
+    "design_considerations": "Reads the cube's encounter class marginal by filtering to rows where class_display is present and all other dimensions are empty; the measure is mapped directly with no re-aggregation. Horizontal orientation chosen from category count.",
+    "tasks": "Compare counts across categories; identify the most or least common category."
+  },
+  {
+    "query_templates": [
+      "How many encounters are there by gender?",
+      "Make a bar chart of encounter count by gender."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] == null && d['ethnicity_display'] == null\"}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"gender\", \"type\": \"nominal\"}, {\"encoding\": \"y\", \"field\": \"cnt\", \"type\": \"quantitative\"}]}}",
+    "creation_method": "template",
+    "chart_type": "barchart",
+    "chart_complexity": "simple",
+    "spec_key_count": 10,
+    "task_types": [
+      "Compute_Derived_Value",
+      "Determine_Range"
+    ],
+    "description": "Shows the pre-aggregated encounter count for each gender as a vertical bar chart.",
+    "design_considerations": "Reads the cube's gender marginal by filtering to rows where gender is present and all other dimensions are empty; the measure is mapped directly with no re-aggregation. Vertical orientation chosen from category count.",
+    "tasks": "Compare counts across categories; identify the most or least common category."
+  },
+  {
+    "query_templates": [
+      "How many encounters are there by race?",
+      "Make a bar chart of encounter count by race."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] != null && d['ethnicity_display'] == null\"}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"y\", \"field\": \"race_display\", \"type\": \"nominal\"}, {\"encoding\": \"x\", \"field\": \"cnt\", \"type\": \"quantitative\"}]}}",
+    "creation_method": "template",
+    "chart_type": "barchart",
+    "chart_complexity": "simple",
+    "spec_key_count": 10,
+    "task_types": [
+      "Compute_Derived_Value",
+      "Determine_Range"
+    ],
+    "description": "Shows the pre-aggregated encounter count for each race as a horizontal bar chart.",
+    "design_considerations": "Reads the cube's race marginal by filtering to rows where race_display is present and all other dimensions are empty; the measure is mapped directly with no re-aggregation. Horizontal orientation chosen from category count.",
+    "tasks": "Compare counts across categories; identify the most or least common category."
+  },
+  {
+    "query_templates": [
+      "How many encounters are there by ethnicity?",
+      "Make a bar chart of encounter count by ethnicity."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && d['ethnicity_display'] != null\"}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"ethnicity_display\", \"type\": \"nominal\"}, {\"encoding\": \"y\", \"field\": \"cnt\", \"type\": \"quantitative\"}]}}",
+    "creation_method": "template",
+    "chart_type": "barchart",
+    "chart_complexity": "simple",
+    "spec_key_count": 10,
+    "task_types": [
+      "Compute_Derived_Value",
+      "Determine_Range"
+    ],
+    "description": "Shows the pre-aggregated encounter count for each ethnicity as a vertical bar chart.",
+    "design_considerations": "Reads the cube's ethnicity marginal by filtering to rows where ethnicity_display is present and all other dimensions are empty; the measure is mapped directly with no re-aggregation. Vertical orientation chosen from category count.",
+    "tasks": "Compare counts across categories; identify the most or least common category."
+  },
+  {
+    "query_templates": [
+      "How many encounters are there by age?",
+      "Make a bar chart of encounter count by age."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] != null && d['gender'] == null && d['race_display'] == null && d['ethnicity_display'] == null\"}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"age_at_visit\", \"type\": \"quantitative\"}, {\"encoding\": \"y\", \"field\": \"cnt\", \"type\": \"quantitative\"}]}}",
+    "creation_method": "template",
+    "chart_type": "barchart",
+    "chart_complexity": "simple",
+    "spec_key_count": 10,
+    "task_types": [
+      "Compute_Derived_Value",
+      "Determine_Range"
+    ],
+    "description": "Shows the pre-aggregated encounter count for each age as a vertical bar chart.",
+    "design_considerations": "Reads the cube's age marginal by filtering to rows where age_at_visit is present and all other dimensions are empty; the measure is mapped directly with no re-aggregation. Vertical orientation chosen from category count.",
+    "tasks": "Compare counts across categories; identify the most or least common category."
+  },
+  {
+    "query_templates": [
+      "How does the encounter count change over month?",
+      "Make a line chart of encounter count over month."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] != null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && d['ethnicity_display'] == null\"}, {\"orderby\": {\"field\": \"period_start_month\", \"order\": \"asc\"}}], \"representation\": {\"mark\": \"line\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"period_start_month\", \"type\": \"ordinal\"}, {\"encoding\": \"y\", \"field\": \"cnt\", \"type\": \"quantitative\"}]}}",
+    "creation_method": "template",
+    "chart_type": "line",
+    "chart_complexity": "simple",
+    "spec_key_count": 12,
+    "task_types": [
+      "Characterize_Distribution",
+      "Determine_Range"
+    ],
+    "description": "Shows the pre-aggregated encounter count over month as a line chart.",
+    "design_considerations": "Filters to the month marginal (all other dimensions empty), orders the axis ascending, and maps the measure directly. The month is encoded as an ordered (ordinal) axis.",
+    "tasks": "Identify trends over time; spot peaks, troughs, and seasonality."
+  },
+  {
+    "query_templates": [
+      "Make a pie chart of encounter count by encounter class."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] != null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && d['ethnicity_display'] == null\"}], \"representation\": {\"mark\": \"arc\", \"mapping\": [{\"encoding\": \"theta\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"color\", \"field\": \"class_display\", \"type\": \"nominal\"}]}}",
+    "creation_method": "template",
+    "chart_type": "circular",
+    "chart_complexity": "simple",
+    "spec_key_count": 10,
+    "task_types": [
+      "Compute_Derived_Value",
+      "Determine_Range"
+    ],
+    "description": "Shows the proportional encounter count for each encounter class as a pie chart.",
+    "design_considerations": "Filters to the encounter class marginal and maps the measure to angle; the renderer normalizes each slice against the total. Suitable for few categories.",
+    "tasks": "Assess part-to-whole proportions; identify the dominant category."
+  },
+  {
+    "query_templates": [
+      "Make a donut chart of encounter count by encounter class."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] != null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && d['ethnicity_display'] == null\"}], \"representation\": {\"mark\": \"arc\", \"mapping\": [{\"encoding\": \"theta\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"color\", \"field\": \"class_display\", \"type\": \"nominal\"}, {\"encoding\": \"radius\", \"value\": 60}, {\"encoding\": \"radius2\", \"value\": 80}]}}",
+    "creation_method": "template",
+    "chart_type": "circular",
+    "chart_complexity": "medium",
+    "spec_key_count": 14,
+    "task_types": [
+      "Compute_Derived_Value",
+      "Determine_Range"
+    ],
+    "description": "Shows the proportional encounter count for each encounter class as a donut chart.",
+    "design_considerations": "Filters to the encounter class marginal and maps the measure to angle; the renderer normalizes each slice against the total. Suitable for few categories.",
+    "tasks": "Assess part-to-whole proportions; identify the dominant category."
+  },
+  {
+    "query_templates": [
+      "How many encounters are there by encounter class and gender?",
+      "Make a stacked bar chart of encounter class and gender."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] != null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] == null && d['ethnicity_display'] == null\"}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"class_display\", \"type\": \"nominal\"}, {\"encoding\": \"y\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"color\", \"field\": \"gender\", \"type\": \"nominal\"}]}}",
+    "creation_method": "template",
+    "chart_type": "stacked_bar",
+    "chart_complexity": "medium",
+    "spec_key_count": 13,
+    "task_types": [
+      "Compute_Derived_Value"
+    ],
+    "description": "Shows the pre-aggregated encounter count by encounter class and gender as a vertical stacked bar chart.",
+    "design_considerations": "Filters to the two-dimension marginal (class_display and gender present, all other dimensions empty) and maps the measure directly. Color encodes the sub-group; prefer the field with fewer categories for color.",
+    "tasks": "Compare group compositions across categories; identify dominant sub-groups."
+  },
+  {
+    "query_templates": [
+      "What is the encounter count of gender for each encounter class?"
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] != null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] == null && d['ethnicity_display'] == null\"}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"class_display\", \"type\": \"nominal\"}, {\"encoding\": \"y\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"xOffset\", \"field\": \"gender\", \"type\": \"nominal\"}, {\"encoding\": \"color\", \"field\": \"gender\", \"type\": \"nominal\"}]}}",
+    "creation_method": "template",
+    "chart_type": "stacked_bar",
+    "chart_complexity": "medium",
+    "spec_key_count": 16,
+    "task_types": [
+      "Compute_Derived_Value"
+    ],
+    "description": "Shows the pre-aggregated encounter count by encounter class and gender as a grouped (side-by-side) bar chart.",
+    "design_considerations": "Filters to the two-dimension marginal and uses xOffset for side-by-side grouping, enabling direct comparison of gender within each encounter class.",
+    "tasks": "Directly compare sub-group counts within and across categories."
+  },
+  {
+    "query_templates": [
+      "What is the proportion of gender for each encounter class?"
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] != null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] == null && d['ethnicity_display'] == null\"}, {\"groupby\": \"class_display\", \"out\": \"groupTotals\"}, {\"rollup\": {\"axis_total\": {\"op\": \"sum\", \"field\": \"cnt\"}}}, {\"groupby\": [\"gender\", \"class_display\"], \"in\": \"<E>\"}, {\"rollup\": {\"cell_total\": {\"op\": \"sum\", \"field\": \"cnt\"}}}, {\"join\": {\"on\": \"class_display\"}, \"in\": [\"<E>\", \"groupTotals\"], \"out\": \"datasets\"}, {\"derive\": {\"proportion\": \"d['cell_total'] / d['axis_total']\"}}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"class_display\", \"type\": \"nominal\"}, {\"encoding\": \"y\", \"field\": \"proportion\", \"type\": \"quantitative\"}, {\"encoding\": \"color\", \"field\": \"gender\", \"type\": \"nominal\"}]}}",
+    "creation_method": "template",
+    "chart_type": "stacked_bar",
+    "chart_complexity": "complex",
+    "spec_key_count": 27,
+    "task_types": [
+      "Compute_Derived_Value"
+    ],
+    "description": "Shows the relative proportion of gender within each encounter class as a normalized stacked bar chart.",
+    "design_considerations": "First filters to the two-dimension marginal, then sums the measure per encounter class and divides each cell by its group total to obtain proportions. Color is preferably the field with fewer categories.",
+    "tasks": "Compare relative proportions across categories; identify dominant sub-groups."
+  },
+  {
+    "query_templates": [
+      "Are there clusters in encounter count across encounter class and gender?",
+      "Make a heatmap of encounter class and gender."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] != null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] == null && d['ethnicity_display'] == null\"}, {\"derive\": {\"udi_internal_percentile\": \"d['cnt'] / max(d['cnt'])\"}}, {\"derive\": {\"udi_internal_text_color_threshold\": \"d.udi_internal_percentile > .5 ? 'large' : 'small'\"}}], \"representation\": [{\"mark\": \"rect\", \"mapping\": [{\"encoding\": \"color\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"y\", \"field\": \"gender\", \"type\": \"nominal\"}, {\"encoding\": \"x\", \"field\": \"class_display\", \"type\": \"nominal\"}]}, {\"mark\": \"text\", \"mapping\": [{\"encoding\": \"text\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"y\", \"field\": \"gender\", \"type\": \"nominal\"}, {\"encoding\": \"x\", \"field\": \"class_display\", \"type\": \"nominal\"}, {\"encoding\": \"color\", \"field\": \"udi_internal_text_color_threshold\", \"type\": \"nominal\", \"domain\": [\"large\", \"small\"], \"range\": [\"white\", \"black\"], \"omitLegend\": true}]}]}",
+    "creation_method": "template",
+    "chart_type": "heatmap",
+    "chart_complexity": "complex",
+    "spec_key_count": 33,
+    "task_types": [
+      "Cluster",
+      "Compute_Derived_Value",
+      "Correlate"
+    ],
+    "description": "Shows the pre-aggregated encounter count for each combination of encounter class and gender as a labeled heatmap.",
+    "design_considerations": "Filters to the two-dimension marginal and maps the measure to cell color; overlaid text shows exact values with contrast-aware color. The field with more categories is preferably on the y-axis.",
+    "tasks": "Identify clusters or patterns across two dimensions; compare counts across combinations."
+  },
+  {
+    "query_templates": [
+      "How many encounters are there by gender and race?",
+      "Make a stacked bar chart of gender and race."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] != null && d['ethnicity_display'] == null\"}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"gender\", \"type\": \"nominal\"}, {\"encoding\": \"y\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"color\", \"field\": \"race_display\", \"type\": \"nominal\"}]}}",
+    "creation_method": "template",
+    "chart_type": "stacked_bar",
+    "chart_complexity": "medium",
+    "spec_key_count": 13,
+    "task_types": [
+      "Compute_Derived_Value"
+    ],
+    "description": "Shows the pre-aggregated encounter count by gender and race as a vertical stacked bar chart.",
+    "design_considerations": "Filters to the two-dimension marginal (gender and race_display present, all other dimensions empty) and maps the measure directly. Color encodes the sub-group; prefer the field with fewer categories for color.",
+    "tasks": "Compare group compositions across categories; identify dominant sub-groups."
+  },
+  {
+    "query_templates": [
+      "What is the encounter count of race for each gender?"
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] != null && d['ethnicity_display'] == null\"}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"gender\", \"type\": \"nominal\"}, {\"encoding\": \"y\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"xOffset\", \"field\": \"race_display\", \"type\": \"nominal\"}, {\"encoding\": \"color\", \"field\": \"race_display\", \"type\": \"nominal\"}]}}",
+    "creation_method": "template",
+    "chart_type": "stacked_bar",
+    "chart_complexity": "medium",
+    "spec_key_count": 16,
+    "task_types": [
+      "Compute_Derived_Value"
+    ],
+    "description": "Shows the pre-aggregated encounter count by gender and race as a grouped (side-by-side) bar chart.",
+    "design_considerations": "Filters to the two-dimension marginal and uses xOffset for side-by-side grouping, enabling direct comparison of race within each gender.",
+    "tasks": "Directly compare sub-group counts within and across categories."
+  },
+  {
+    "query_templates": [
+      "What is the proportion of race for each gender?"
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] != null && d['ethnicity_display'] == null\"}, {\"groupby\": \"gender\", \"out\": \"groupTotals\"}, {\"rollup\": {\"axis_total\": {\"op\": \"sum\", \"field\": \"cnt\"}}}, {\"groupby\": [\"race_display\", \"gender\"], \"in\": \"<E>\"}, {\"rollup\": {\"cell_total\": {\"op\": \"sum\", \"field\": \"cnt\"}}}, {\"join\": {\"on\": \"gender\"}, \"in\": [\"<E>\", \"groupTotals\"], \"out\": \"datasets\"}, {\"derive\": {\"proportion\": \"d['cell_total'] / d['axis_total']\"}}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"gender\", \"type\": \"nominal\"}, {\"encoding\": \"y\", \"field\": \"proportion\", \"type\": \"quantitative\"}, {\"encoding\": \"color\", \"field\": \"race_display\", \"type\": \"nominal\"}]}}",
+    "creation_method": "template",
+    "chart_type": "stacked_bar",
+    "chart_complexity": "complex",
+    "spec_key_count": 27,
+    "task_types": [
+      "Compute_Derived_Value"
+    ],
+    "description": "Shows the relative proportion of race within each gender as a normalized stacked bar chart.",
+    "design_considerations": "First filters to the two-dimension marginal, then sums the measure per gender and divides each cell by its group total to obtain proportions. Color is preferably the field with fewer categories.",
+    "tasks": "Compare relative proportions across categories; identify dominant sub-groups."
+  },
+  {
+    "query_templates": [
+      "Are there clusters in encounter count across gender and race?",
+      "Make a heatmap of gender and race."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] != null && d['ethnicity_display'] == null\"}, {\"derive\": {\"udi_internal_percentile\": \"d['cnt'] / max(d['cnt'])\"}}, {\"derive\": {\"udi_internal_text_color_threshold\": \"d.udi_internal_percentile > .5 ? 'large' : 'small'\"}}], \"representation\": [{\"mark\": \"rect\", \"mapping\": [{\"encoding\": \"color\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"y\", \"field\": \"race_display\", \"type\": \"nominal\"}, {\"encoding\": \"x\", \"field\": \"gender\", \"type\": \"nominal\"}]}, {\"mark\": \"text\", \"mapping\": [{\"encoding\": \"text\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"y\", \"field\": \"race_display\", \"type\": \"nominal\"}, {\"encoding\": \"x\", \"field\": \"gender\", \"type\": \"nominal\"}, {\"encoding\": \"color\", \"field\": \"udi_internal_text_color_threshold\", \"type\": \"nominal\", \"domain\": [\"large\", \"small\"], \"range\": [\"white\", \"black\"], \"omitLegend\": true}]}]}",
+    "creation_method": "template",
+    "chart_type": "heatmap",
+    "chart_complexity": "complex",
+    "spec_key_count": 33,
+    "task_types": [
+      "Cluster",
+      "Compute_Derived_Value",
+      "Correlate"
+    ],
+    "description": "Shows the pre-aggregated encounter count for each combination of gender and race as a labeled heatmap.",
+    "design_considerations": "Filters to the two-dimension marginal and maps the measure to cell color; overlaid text shows exact values with contrast-aware color. The field with more categories is preferably on the y-axis.",
+    "tasks": "Identify clusters or patterns across two dimensions; compare counts across combinations."
+  },
+  {
+    "query_templates": [
+      "How many encounters are there by race and ethnicity?",
+      "Make a stacked bar chart of race and ethnicity."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] != null && d['ethnicity_display'] != null\"}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"race_display\", \"type\": \"nominal\"}, {\"encoding\": \"y\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"color\", \"field\": \"ethnicity_display\", \"type\": \"nominal\"}]}}",
+    "creation_method": "template",
+    "chart_type": "stacked_bar",
+    "chart_complexity": "medium",
+    "spec_key_count": 13,
+    "task_types": [
+      "Compute_Derived_Value"
+    ],
+    "description": "Shows the pre-aggregated encounter count by race and ethnicity as a vertical stacked bar chart.",
+    "design_considerations": "Filters to the two-dimension marginal (race_display and ethnicity_display present, all other dimensions empty) and maps the measure directly. Color encodes the sub-group; prefer the field with fewer categories for color.",
+    "tasks": "Compare group compositions across categories; identify dominant sub-groups."
+  },
+  {
+    "query_templates": [
+      "What is the encounter count of ethnicity for each race?"
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] != null && d['ethnicity_display'] != null\"}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"race_display\", \"type\": \"nominal\"}, {\"encoding\": \"y\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"xOffset\", \"field\": \"ethnicity_display\", \"type\": \"nominal\"}, {\"encoding\": \"color\", \"field\": \"ethnicity_display\", \"type\": \"nominal\"}]}}",
+    "creation_method": "template",
+    "chart_type": "stacked_bar",
+    "chart_complexity": "medium",
+    "spec_key_count": 16,
+    "task_types": [
+      "Compute_Derived_Value"
+    ],
+    "description": "Shows the pre-aggregated encounter count by race and ethnicity as a grouped (side-by-side) bar chart.",
+    "design_considerations": "Filters to the two-dimension marginal and uses xOffset for side-by-side grouping, enabling direct comparison of ethnicity within each race.",
+    "tasks": "Directly compare sub-group counts within and across categories."
+  },
+  {
+    "query_templates": [
+      "What is the proportion of ethnicity for each race?"
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] != null && d['ethnicity_display'] != null\"}, {\"groupby\": \"race_display\", \"out\": \"groupTotals\"}, {\"rollup\": {\"axis_total\": {\"op\": \"sum\", \"field\": \"cnt\"}}}, {\"groupby\": [\"ethnicity_display\", \"race_display\"], \"in\": \"<E>\"}, {\"rollup\": {\"cell_total\": {\"op\": \"sum\", \"field\": \"cnt\"}}}, {\"join\": {\"on\": \"race_display\"}, \"in\": [\"<E>\", \"groupTotals\"], \"out\": \"datasets\"}, {\"derive\": {\"proportion\": \"d['cell_total'] / d['axis_total']\"}}], \"representation\": {\"mark\": \"bar\", \"mapping\": [{\"encoding\": \"x\", \"field\": \"race_display\", \"type\": \"nominal\"}, {\"encoding\": \"y\", \"field\": \"proportion\", \"type\": \"quantitative\"}, {\"encoding\": \"color\", \"field\": \"ethnicity_display\", \"type\": \"nominal\"}]}}",
+    "creation_method": "template",
+    "chart_type": "stacked_bar",
+    "chart_complexity": "complex",
+    "spec_key_count": 27,
+    "task_types": [
+      "Compute_Derived_Value"
+    ],
+    "description": "Shows the relative proportion of ethnicity within each race as a normalized stacked bar chart.",
+    "design_considerations": "First filters to the two-dimension marginal, then sums the measure per race and divides each cell by its group total to obtain proportions. Color is preferably the field with fewer categories.",
+    "tasks": "Compare relative proportions across categories; identify dominant sub-groups."
+  },
+  {
+    "query_templates": [
+      "Are there clusters in encounter count across race and ethnicity?",
+      "Make a heatmap of race and ethnicity."
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] != null && d['ethnicity_display'] != null\"}, {\"derive\": {\"udi_internal_percentile\": \"d['cnt'] / max(d['cnt'])\"}}, {\"derive\": {\"udi_internal_text_color_threshold\": \"d.udi_internal_percentile > .5 ? 'large' : 'small'\"}}], \"representation\": [{\"mark\": \"rect\", \"mapping\": [{\"encoding\": \"color\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"y\", \"field\": \"ethnicity_display\", \"type\": \"nominal\"}, {\"encoding\": \"x\", \"field\": \"race_display\", \"type\": \"nominal\"}]}, {\"mark\": \"text\", \"mapping\": [{\"encoding\": \"text\", \"field\": \"cnt\", \"type\": \"quantitative\"}, {\"encoding\": \"y\", \"field\": \"ethnicity_display\", \"type\": \"nominal\"}, {\"encoding\": \"x\", \"field\": \"race_display\", \"type\": \"nominal\"}, {\"encoding\": \"color\", \"field\": \"udi_internal_text_color_threshold\", \"type\": \"nominal\", \"domain\": [\"large\", \"small\"], \"range\": [\"white\", \"black\"], \"omitLegend\": true}]}]}",
+    "creation_method": "template",
+    "chart_type": "heatmap",
+    "chart_complexity": "complex",
+    "spec_key_count": 33,
+    "task_types": [
+      "Cluster",
+      "Compute_Derived_Value",
+      "Correlate"
+    ],
+    "description": "Shows the pre-aggregated encounter count for each combination of race and ethnicity as a labeled heatmap.",
+    "design_considerations": "Filters to the two-dimension marginal and maps the measure to cell color; overlaid text shows exact values with contrast-aware color. The field with more categories is preferably on the y-axis.",
+    "tasks": "Identify clusters or patterns across two dimensions; compare counts across combinations."
+  },
+  {
+    "query_templates": [
+      "How many encounters are there in total?",
+      "What is the total encounter count?"
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && d['ethnicity_display'] == null\"}], \"representation\": {\"mark\": \"row\", \"mapping\": [{\"encoding\": \"text\", \"field\": \"cnt\", \"mark\": \"text\", \"type\": \"nominal\"}]}}",
+    "creation_method": "template",
+    "chart_type": "table",
+    "chart_complexity": "simple",
+    "spec_key_count": 8,
+    "task_types": [
+      "Retrieve_Value",
+      "Compute_Derived_Value"
+    ],
+    "description": "Shows the grand-total encounter count as a single-row table.",
+    "design_considerations": "Reads the grand-total row directly by filtering to the marginal where every dimension is empty; no aggregation is performed.",
+    "tasks": "Retrieve the overall total."
+  },
+  {
+    "query_templates": [
+      "List the encounter count for each encounter class.",
+      "What is the range of encounter class values?"
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] != null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && d['ethnicity_display'] == null\"}, {\"orderby\": {\"field\": \"cnt\", \"order\": \"desc\"}}], \"representation\": {\"mark\": \"row\", \"mapping\": [{\"encoding\": \"text\", \"field\": \"class_display\", \"mark\": \"text\", \"type\": \"nominal\"}, {\"encoding\": \"x\", \"field\": \"cnt\", \"mark\": \"bar\", \"type\": \"quantitative\", \"range\": {\"min\": 0.1, \"max\": 1}}]}}",
+    "creation_method": "template",
+    "chart_type": "table",
+    "chart_complexity": "medium",
+    "spec_key_count": 16,
+    "task_types": [
+      "Determine_Range",
+      "Sort",
+      "Retrieve_Value"
+    ],
+    "description": "Lists each encounter class with its pre-aggregated encounter count as a sorted table with in-cell bars.",
+    "design_considerations": "Filters to the encounter class marginal, orders by the measure, and adds in-cell bars for visual comparison.",
+    "tasks": "Determine the distinct values of a dimension; compare category counts."
+  },
+  {
+    "query_templates": [
+      "List the encounter count for each gender.",
+      "What is the range of gender values?"
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] == null && d['ethnicity_display'] == null\"}, {\"orderby\": {\"field\": \"cnt\", \"order\": \"desc\"}}], \"representation\": {\"mark\": \"row\", \"mapping\": [{\"encoding\": \"text\", \"field\": \"gender\", \"mark\": \"text\", \"type\": \"nominal\"}, {\"encoding\": \"x\", \"field\": \"cnt\", \"mark\": \"bar\", \"type\": \"quantitative\", \"range\": {\"min\": 0.1, \"max\": 1}}]}}",
+    "creation_method": "template",
+    "chart_type": "table",
+    "chart_complexity": "medium",
+    "spec_key_count": 16,
+    "task_types": [
+      "Determine_Range",
+      "Sort",
+      "Retrieve_Value"
+    ],
+    "description": "Lists each gender with its pre-aggregated encounter count as a sorted table with in-cell bars.",
+    "design_considerations": "Filters to the gender marginal, orders by the measure, and adds in-cell bars for visual comparison.",
+    "tasks": "Determine the distinct values of a dimension; compare category counts."
+  },
+  {
+    "query_templates": [
+      "List the encounter count for each race.",
+      "What is the range of race values?"
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] != null && d['ethnicity_display'] == null\"}, {\"orderby\": {\"field\": \"cnt\", \"order\": \"desc\"}}], \"representation\": {\"mark\": \"row\", \"mapping\": [{\"encoding\": \"text\", \"field\": \"race_display\", \"mark\": \"text\", \"type\": \"nominal\"}, {\"encoding\": \"x\", \"field\": \"cnt\", \"mark\": \"bar\", \"type\": \"quantitative\", \"range\": {\"min\": 0.1, \"max\": 1}}]}}",
+    "creation_method": "template",
+    "chart_type": "table",
+    "chart_complexity": "medium",
+    "spec_key_count": 16,
+    "task_types": [
+      "Determine_Range",
+      "Sort",
+      "Retrieve_Value"
+    ],
+    "description": "Lists each race with its pre-aggregated encounter count as a sorted table with in-cell bars.",
+    "design_considerations": "Filters to the race marginal, orders by the measure, and adds in-cell bars for visual comparison.",
+    "tasks": "Determine the distinct values of a dimension; compare category counts."
+  },
+  {
+    "query_templates": [
+      "List the encounter count for each ethnicity.",
+      "What is the range of ethnicity values?"
+    ],
+    "spec_template": "{\"source\": {\"name\": \"<E>\", \"source\": \"<E.url>\"}, \"transformation\": [{\"filter\": \"d['period_start_month'] == null && d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && d['ethnicity_display'] != null\"}, {\"orderby\": {\"field\": \"cnt\", \"order\": \"desc\"}}], \"representation\": {\"mark\": \"row\", \"mapping\": [{\"encoding\": \"text\", \"field\": \"ethnicity_display\", \"mark\": \"text\", \"type\": \"nominal\"}, {\"encoding\": \"x\", \"field\": \"cnt\", \"mark\": \"bar\", \"type\": \"quantitative\", \"range\": {\"min\": 0.1, \"max\": 1}}]}}",
+    "creation_method": "template",
+    "chart_type": "table",
+    "chart_complexity": "medium",
+    "spec_key_count": 16,
+    "task_types": [
+      "Determine_Range",
+      "Sort",
+      "Retrieve_Value"
+    ],
+    "description": "Lists each ethnicity with its pre-aggregated encounter count as a sorted table with in-cell bars.",
+    "design_considerations": "Filters to the ethnicity marginal, orders by the measure, and adds in-cell bars for visual comparison.",
+    "tasks": "Determine the distinct values of a dimension; compare category counts."
+  }
+]

--- a/src/udiagent/generated_vis_tools_cube.py
+++ b/src/udiagent/generated_vis_tools_cube.py
@@ -1,0 +1,521 @@
+"""
+Auto-generated visualization tool definitions.
+
+Generated from: src/udiagent/data/skills/template_visualizations_cube.json
+Schema: data/data_domains/encounter_cube_schema.json
+Tools: 25
+
+DO NOT EDIT — regenerate with: python src/generate_tools.py
+"""
+
+
+# Schema metadata (entity URLs and relationships)
+SCHEMA = {'entities': {'encounter_counts': {'fields': {'age_at_visit': {'cardinality': 97, 'type': 'quantitative'},
+                                              'class_display': {'cardinality': 5, 'type': 'nominal'},
+                                              'cnt': {'cardinality': 1327, 'type': 'quantitative'},
+                                              'ethnicity_display': {'cardinality': 2, 'type': 'nominal'},
+                                              'gender': {'cardinality': 2, 'type': 'nominal'},
+                                              'period_start_month': {'cardinality': 881, 'type': 'temporal'},
+                                              'race_display': {'cardinality': 5, 'type': 'nominal'}},
+                                   'url': './data/example_data_cube/core__count_encounter_month.csv'}},
+ 'relationships': []}
+
+
+# Spec template strings (indexed by position)
+TEMPLATES = ['{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] != null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] == null"}], "representation": {"mark": "bar", "mapping": [{"encoding": "y", "field": '
+ '"class_display", "type": "nominal"}, {"encoding": "x", "field": "cnt", "type": "quantitative"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] == null"}], "representation": {"mark": "bar", "mapping": [{"encoding": "x", "field": '
+ '"gender", "type": "nominal"}, {"encoding": "y", "field": "cnt", "type": "quantitative"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] != null && "
+ 'd[\'ethnicity_display\'] == null"}], "representation": {"mark": "bar", "mapping": [{"encoding": "y", "field": '
+ '"race_display", "type": "nominal"}, {"encoding": "x", "field": "cnt", "type": "quantitative"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] != null"}], "representation": {"mark": "bar", "mapping": [{"encoding": "x", "field": '
+ '"ethnicity_display", "type": "nominal"}, {"encoding": "y", "field": "cnt", "type": "quantitative"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] != null && d['gender'] == null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] == null"}], "representation": {"mark": "bar", "mapping": [{"encoding": "x", "field": '
+ '"age_at_visit", "type": "quantitative"}, {"encoding": "y", "field": "cnt", "type": "quantitative"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] != null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] == null"}, {"orderby": {"field": "period_start_month", "order": "asc"}}], "representation": '
+ '{"mark": "line", "mapping": [{"encoding": "x", "field": "period_start_month", "type": "ordinal"}, {"encoding": "y", '
+ '"field": "cnt", "type": "quantitative"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] != null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] == null"}], "representation": {"mark": "arc", "mapping": [{"encoding": "theta", "field": '
+ '"cnt", "type": "quantitative"}, {"encoding": "color", "field": "class_display", "type": "nominal"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] != null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] == null"}], "representation": {"mark": "arc", "mapping": [{"encoding": "theta", "field": '
+ '"cnt", "type": "quantitative"}, {"encoding": "color", "field": "class_display", "type": "nominal"}, {"encoding": '
+ '"radius", "value": 60}, {"encoding": "radius2", "value": 80}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] != null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] == null"}], "representation": {"mark": "bar", "mapping": [{"encoding": "x", "field": '
+ '"class_display", "type": "nominal"}, {"encoding": "y", "field": "cnt", "type": "quantitative"}, {"encoding": '
+ '"color", "field": "gender", "type": "nominal"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] != null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] == null"}], "representation": {"mark": "bar", "mapping": [{"encoding": "x", "field": '
+ '"class_display", "type": "nominal"}, {"encoding": "y", "field": "cnt", "type": "quantitative"}, {"encoding": '
+ '"xOffset", "field": "gender", "type": "nominal"}, {"encoding": "color", "field": "gender", "type": "nominal"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] != null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] == null"}, {"groupby": "class_display", "out": "groupTotals"}, {"rollup": {"axis_total": '
+ '{"op": "sum", "field": "cnt"}}}, {"groupby": ["gender", "class_display"], "in": "<E>"}, {"rollup": {"cell_total": '
+ '{"op": "sum", "field": "cnt"}}}, {"join": {"on": "class_display"}, "in": ["<E>", "groupTotals"], "out": "datasets"}, '
+ '{"derive": {"proportion": "d[\'cell_total\'] / d[\'axis_total\']"}}], "representation": {"mark": "bar", "mapping": '
+ '[{"encoding": "x", "field": "class_display", "type": "nominal"}, {"encoding": "y", "field": "proportion", "type": '
+ '"quantitative"}, {"encoding": "color", "field": "gender", "type": "nominal"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] != null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] == null"}, {"derive": {"udi_internal_percentile": "d[\'cnt\'] / max(d[\'cnt\'])"}}, '
+ '{"derive": {"udi_internal_text_color_threshold": "d.udi_internal_percentile > .5 ? \'large\' : \'small\'"}}], '
+ '"representation": [{"mark": "rect", "mapping": [{"encoding": "color", "field": "cnt", "type": "quantitative"}, '
+ '{"encoding": "y", "field": "gender", "type": "nominal"}, {"encoding": "x", "field": "class_display", "type": '
+ '"nominal"}]}, {"mark": "text", "mapping": [{"encoding": "text", "field": "cnt", "type": "quantitative"}, '
+ '{"encoding": "y", "field": "gender", "type": "nominal"}, {"encoding": "x", "field": "class_display", "type": '
+ '"nominal"}, {"encoding": "color", "field": "udi_internal_text_color_threshold", "type": "nominal", "domain": '
+ '["large", "small"], "range": ["white", "black"], "omitLegend": true}]}]}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] != null && "
+ 'd[\'ethnicity_display\'] == null"}], "representation": {"mark": "bar", "mapping": [{"encoding": "x", "field": '
+ '"gender", "type": "nominal"}, {"encoding": "y", "field": "cnt", "type": "quantitative"}, {"encoding": "color", '
+ '"field": "race_display", "type": "nominal"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] != null && "
+ 'd[\'ethnicity_display\'] == null"}], "representation": {"mark": "bar", "mapping": [{"encoding": "x", "field": '
+ '"gender", "type": "nominal"}, {"encoding": "y", "field": "cnt", "type": "quantitative"}, {"encoding": "xOffset", '
+ '"field": "race_display", "type": "nominal"}, {"encoding": "color", "field": "race_display", "type": "nominal"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] != null && "
+ 'd[\'ethnicity_display\'] == null"}, {"groupby": "gender", "out": "groupTotals"}, {"rollup": {"axis_total": {"op": '
+ '"sum", "field": "cnt"}}}, {"groupby": ["race_display", "gender"], "in": "<E>"}, {"rollup": {"cell_total": {"op": '
+ '"sum", "field": "cnt"}}}, {"join": {"on": "gender"}, "in": ["<E>", "groupTotals"], "out": "datasets"}, {"derive": '
+ '{"proportion": "d[\'cell_total\'] / d[\'axis_total\']"}}], "representation": {"mark": "bar", "mapping": '
+ '[{"encoding": "x", "field": "gender", "type": "nominal"}, {"encoding": "y", "field": "proportion", "type": '
+ '"quantitative"}, {"encoding": "color", "field": "race_display", "type": "nominal"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] != null && "
+ 'd[\'ethnicity_display\'] == null"}, {"derive": {"udi_internal_percentile": "d[\'cnt\'] / max(d[\'cnt\'])"}}, '
+ '{"derive": {"udi_internal_text_color_threshold": "d.udi_internal_percentile > .5 ? \'large\' : \'small\'"}}], '
+ '"representation": [{"mark": "rect", "mapping": [{"encoding": "color", "field": "cnt", "type": "quantitative"}, '
+ '{"encoding": "y", "field": "race_display", "type": "nominal"}, {"encoding": "x", "field": "gender", "type": '
+ '"nominal"}]}, {"mark": "text", "mapping": [{"encoding": "text", "field": "cnt", "type": "quantitative"}, '
+ '{"encoding": "y", "field": "race_display", "type": "nominal"}, {"encoding": "x", "field": "gender", "type": '
+ '"nominal"}, {"encoding": "color", "field": "udi_internal_text_color_threshold", "type": "nominal", "domain": '
+ '["large", "small"], "range": ["white", "black"], "omitLegend": true}]}]}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] != null && "
+ 'd[\'ethnicity_display\'] != null"}], "representation": {"mark": "bar", "mapping": [{"encoding": "x", "field": '
+ '"race_display", "type": "nominal"}, {"encoding": "y", "field": "cnt", "type": "quantitative"}, {"encoding": "color", '
+ '"field": "ethnicity_display", "type": "nominal"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] != null && "
+ 'd[\'ethnicity_display\'] != null"}], "representation": {"mark": "bar", "mapping": [{"encoding": "x", "field": '
+ '"race_display", "type": "nominal"}, {"encoding": "y", "field": "cnt", "type": "quantitative"}, {"encoding": '
+ '"xOffset", "field": "ethnicity_display", "type": "nominal"}, {"encoding": "color", "field": "ethnicity_display", '
+ '"type": "nominal"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] != null && "
+ 'd[\'ethnicity_display\'] != null"}, {"groupby": "race_display", "out": "groupTotals"}, {"rollup": {"axis_total": '
+ '{"op": "sum", "field": "cnt"}}}, {"groupby": ["ethnicity_display", "race_display"], "in": "<E>"}, {"rollup": '
+ '{"cell_total": {"op": "sum", "field": "cnt"}}}, {"join": {"on": "race_display"}, "in": ["<E>", "groupTotals"], '
+ '"out": "datasets"}, {"derive": {"proportion": "d[\'cell_total\'] / d[\'axis_total\']"}}], "representation": {"mark": '
+ '"bar", "mapping": [{"encoding": "x", "field": "race_display", "type": "nominal"}, {"encoding": "y", "field": '
+ '"proportion", "type": "quantitative"}, {"encoding": "color", "field": "ethnicity_display", "type": "nominal"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] != null && "
+ 'd[\'ethnicity_display\'] != null"}, {"derive": {"udi_internal_percentile": "d[\'cnt\'] / max(d[\'cnt\'])"}}, '
+ '{"derive": {"udi_internal_text_color_threshold": "d.udi_internal_percentile > .5 ? \'large\' : \'small\'"}}], '
+ '"representation": [{"mark": "rect", "mapping": [{"encoding": "color", "field": "cnt", "type": "quantitative"}, '
+ '{"encoding": "y", "field": "ethnicity_display", "type": "nominal"}, {"encoding": "x", "field": "race_display", '
+ '"type": "nominal"}]}, {"mark": "text", "mapping": [{"encoding": "text", "field": "cnt", "type": "quantitative"}, '
+ '{"encoding": "y", "field": "ethnicity_display", "type": "nominal"}, {"encoding": "x", "field": "race_display", '
+ '"type": "nominal"}, {"encoding": "color", "field": "udi_internal_text_color_threshold", "type": "nominal", "domain": '
+ '["large", "small"], "range": ["white", "black"], "omitLegend": true}]}]}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] == null"}], "representation": {"mark": "row", "mapping": [{"encoding": "text", "field": '
+ '"cnt", "mark": "text", "type": "nominal"}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] != null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] == null"}, {"orderby": {"field": "cnt", "order": "desc"}}], "representation": {"mark": '
+ '"row", "mapping": [{"encoding": "text", "field": "class_display", "mark": "text", "type": "nominal"}, {"encoding": '
+ '"x", "field": "cnt", "mark": "bar", "type": "quantitative", "range": {"min": 0.1, "max": 1}}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] != null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] == null"}, {"orderby": {"field": "cnt", "order": "desc"}}], "representation": {"mark": '
+ '"row", "mapping": [{"encoding": "text", "field": "gender", "mark": "text", "type": "nominal"}, {"encoding": "x", '
+ '"field": "cnt", "mark": "bar", "type": "quantitative", "range": {"min": 0.1, "max": 1}}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] != null && "
+ 'd[\'ethnicity_display\'] == null"}, {"orderby": {"field": "cnt", "order": "desc"}}], "representation": {"mark": '
+ '"row", "mapping": [{"encoding": "text", "field": "race_display", "mark": "text", "type": "nominal"}, {"encoding": '
+ '"x", "field": "cnt", "mark": "bar", "type": "quantitative", "range": {"min": 0.1, "max": 1}}]}}',
+ '{"source": {"name": "<E>", "source": "<E.url>"}, "transformation": [{"filter": "d[\'period_start_month\'] == null && '
+ "d['class_display'] == null && d['age_at_visit'] == null && d['gender'] == null && d['race_display'] == null && "
+ 'd[\'ethnicity_display\'] != null"}, {"orderby": {"field": "cnt", "order": "desc"}}], "representation": {"mark": '
+ '"row", "mapping": [{"encoding": "text", "field": "ethnicity_display", "mark": "text", "type": "nominal"}, '
+ '{"encoding": "x", "field": "cnt", "mark": "bar", "type": "quantitative", "range": {"min": 0.1, "max": 1}}]}}']
+
+
+# OpenAI function-calling tool definitions
+TOOL_DEFS = [{'function': {'description': '[barchart] Shows the pre-aggregated encounter count for each encounter class as a '
+                              "horizontal bar chart. Design: Reads the cube's encounter class marginal by filtering to "
+                              'rows where class_display is present and all other dimensions are empty; the measure is '
+                              'mapped directly with no re-aggregation. Horizontal orientation chosen from category '
+                              'count. Tasks: Compare counts across categories; identify the most or least common '
+                              'category. Query patterns: How many encounters are there by encounter class?; Make a bar '
+                              'chart of encounter count by encounter class.',
+               'name': 'vis_000_barchart_count_horiz',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[barchart] Shows the pre-aggregated encounter count for each gender as a vertical bar '
+                              "chart. Design: Reads the cube's gender marginal by filtering to rows where gender is "
+                              'present and all other dimensions are empty; the measure is mapped directly with no '
+                              're-aggregation. Vertical orientation chosen from category count. Tasks: Compare counts '
+                              'across categories; identify the most or least common category. Query patterns: How many '
+                              'encounters are there by gender?; Make a bar chart of encounter count by gender.',
+               'name': 'vis_001_barchart_count_vert',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[barchart] Shows the pre-aggregated encounter count for each race as a horizontal bar '
+                              "chart. Design: Reads the cube's race marginal by filtering to rows where race_display "
+                              'is present and all other dimensions are empty; the measure is mapped directly with no '
+                              're-aggregation. Horizontal orientation chosen from category count. Tasks: Compare '
+                              'counts across categories; identify the most or least common category. Query patterns: '
+                              'How many encounters are there by race?; Make a bar chart of encounter count by race.',
+               'name': 'vis_002_barchart_count_horiz',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[barchart] Shows the pre-aggregated encounter count for each ethnicity as a vertical '
+                              "bar chart. Design: Reads the cube's ethnicity marginal by filtering to rows where "
+                              'ethnicity_display is present and all other dimensions are empty; the measure is mapped '
+                              'directly with no re-aggregation. Vertical orientation chosen from category count. '
+                              'Tasks: Compare counts across categories; identify the most or least common category. '
+                              'Query patterns: How many encounters are there by ethnicity?; Make a bar chart of '
+                              'encounter count by ethnicity.',
+               'name': 'vis_003_barchart_count_vert',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[barchart] Shows the pre-aggregated encounter count for each age as a vertical bar '
+                              "chart. Design: Reads the cube's age marginal by filtering to rows where age_at_visit is "
+                              'present and all other dimensions are empty; the measure is mapped directly with no '
+                              're-aggregation. Vertical orientation chosen from category count. Tasks: Compare counts '
+                              'across categories; identify the most or least common category. Query patterns: How many '
+                              'encounters are there by age?; Make a bar chart of encounter count by age.',
+               'name': 'vis_004_barchart_count_vert',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[line] Shows the pre-aggregated encounter count over month as a line chart. Design: '
+                              'Filters to the month marginal (all other dimensions empty), orders the axis ascending, '
+                              'and maps the measure directly. The month is encoded as an ordered (ordinal) axis. '
+                              'Tasks: Identify trends over time; spot peaks, troughs, and seasonality. Query patterns: '
+                              'How does the encounter count change over month?; Make a line chart of encounter count '
+                              'over month.',
+               'name': 'vis_005_line_count',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[circular] Shows the proportional encounter count for each encounter class as a pie '
+                              'chart. Design: Filters to the encounter class marginal and maps the measure to angle; '
+                              'the renderer normalizes each slice against the total. Suitable for few categories. '
+                              'Tasks: Assess part-to-whole proportions; identify the dominant category. Query '
+                              'patterns: Make a pie chart of encounter count by encounter class.',
+               'name': 'vis_006_circular_count',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[circular] Shows the proportional encounter count for each encounter class as a donut '
+                              'chart. Design: Filters to the encounter class marginal and maps the measure to angle; '
+                              'the renderer normalizes each slice against the total. Suitable for few categories. '
+                              'Tasks: Assess part-to-whole proportions; identify the dominant category. Query '
+                              'patterns: Make a donut chart of encounter count by encounter class.',
+               'name': 'vis_007_circular_count',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[stacked_bar] Shows the pre-aggregated encounter count by encounter class and gender as '
+                              'a vertical stacked bar chart. Design: Filters to the two-dimension marginal '
+                              '(class_display and gender present, all other dimensions empty) and maps the measure '
+                              'directly. Color encodes the sub-group; prefer the field with fewer categories for '
+                              'color. Tasks: Compare group compositions across categories; identify dominant '
+                              'sub-groups. Query patterns: How many encounters are there by encounter class and '
+                              'gender?; Make a stacked bar chart of encounter class and gender.',
+               'name': 'vis_008_stacked_bar_count_vert_stacked',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[stacked_bar] Shows the pre-aggregated encounter count by encounter class and gender as '
+                              'a grouped (side-by-side) bar chart. Design: Filters to the two-dimension marginal and '
+                              'uses xOffset for side-by-side grouping, enabling direct comparison of gender within '
+                              'each encounter class. Tasks: Directly compare sub-group counts within and across '
+                              'categories. Query patterns: What is the encounter count of gender for each encounter '
+                              'class?',
+               'name': 'vis_009_stacked_bar_count_grouped',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[stacked_bar] Shows the relative proportion of gender within each encounter class as a '
+                              'normalized stacked bar chart. Design: First filters to the two-dimension marginal, then '
+                              'sums the measure per encounter class and divides each cell by its group total to obtain '
+                              'proportions. Color is preferably the field with fewer categories. Tasks: Compare '
+                              'relative proportions across categories; identify dominant sub-groups. Query patterns: '
+                              'What is the proportion of gender for each encounter class?',
+               'name': 'vis_010_stacked_bar_count_stacked_normalized',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[heatmap] Shows the pre-aggregated encounter count for each combination of encounter '
+                              'class and gender as a labeled heatmap. Design: Filters to the two-dimension marginal '
+                              'and maps the measure to cell color; overlaid text shows exact values with '
+                              'contrast-aware color. The field with more categories is preferably on the y-axis. '
+                              'Tasks: Identify clusters or patterns across two dimensions; compare counts across '
+                              'combinations. Query patterns: Are there clusters in encounter count across encounter '
+                              'class and gender?; Make a heatmap of encounter class and gender.',
+               'name': 'vis_011_heatmap_count',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[stacked_bar] Shows the pre-aggregated encounter count by gender and race as a vertical '
+                              'stacked bar chart. Design: Filters to the two-dimension marginal (gender and '
+                              'race_display present, all other dimensions empty) and maps the measure directly. Color '
+                              'encodes the sub-group; prefer the field with fewer categories for color. Tasks: Compare '
+                              'group compositions across categories; identify dominant sub-groups. Query patterns: How '
+                              'many encounters are there by gender and race?; Make a stacked bar chart of gender and '
+                              'race.',
+               'name': 'vis_012_stacked_bar_count_vert_stacked',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[stacked_bar] Shows the pre-aggregated encounter count by gender and race as a grouped '
+                              '(side-by-side) bar chart. Design: Filters to the two-dimension marginal and uses '
+                              'xOffset for side-by-side grouping, enabling direct comparison of race within each '
+                              'gender. Tasks: Directly compare sub-group counts within and across categories. Query '
+                              'patterns: What is the encounter count of race for each gender?',
+               'name': 'vis_013_stacked_bar_count_grouped',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[stacked_bar] Shows the relative proportion of race within each gender as a normalized '
+                              'stacked bar chart. Design: First filters to the two-dimension marginal, then sums the '
+                              'measure per gender and divides each cell by its group total to obtain proportions. '
+                              'Color is preferably the field with fewer categories. Tasks: Compare relative '
+                              'proportions across categories; identify dominant sub-groups. Query patterns: What is '
+                              'the proportion of race for each gender?',
+               'name': 'vis_014_stacked_bar_proportion_stacked_normalized',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[heatmap] Shows the pre-aggregated encounter count for each combination of gender and '
+                              'race as a labeled heatmap. Design: Filters to the two-dimension marginal and maps the '
+                              'measure to cell color; overlaid text shows exact values with contrast-aware color. The '
+                              'field with more categories is preferably on the y-axis. Tasks: Identify clusters or '
+                              'patterns across two dimensions; compare counts across combinations. Query patterns: Are '
+                              'there clusters in encounter count across gender and race?; Make a heatmap of gender and '
+                              'race.',
+               'name': 'vis_015_heatmap_count',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[stacked_bar] Shows the pre-aggregated encounter count by race and ethnicity as a '
+                              'vertical stacked bar chart. Design: Filters to the two-dimension marginal (race_display '
+                              'and ethnicity_display present, all other dimensions empty) and maps the measure '
+                              'directly. Color encodes the sub-group; prefer the field with fewer categories for '
+                              'color. Tasks: Compare group compositions across categories; identify dominant '
+                              'sub-groups. Query patterns: How many encounters are there by race and ethnicity?; Make '
+                              'a stacked bar chart of race and ethnicity.',
+               'name': 'vis_016_stacked_bar_count_vert_stacked',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[stacked_bar] Shows the pre-aggregated encounter count by race and ethnicity as a '
+                              'grouped (side-by-side) bar chart. Design: Filters to the two-dimension marginal and '
+                              'uses xOffset for side-by-side grouping, enabling direct comparison of ethnicity within '
+                              'each race. Tasks: Directly compare sub-group counts within and across categories. Query '
+                              'patterns: What is the encounter count of ethnicity for each race?',
+               'name': 'vis_017_stacked_bar_count_grouped',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[stacked_bar] Shows the relative proportion of ethnicity within each race as a '
+                              'normalized stacked bar chart. Design: First filters to the two-dimension marginal, then '
+                              'sums the measure per race and divides each cell by its group total to obtain '
+                              'proportions. Color is preferably the field with fewer categories. Tasks: Compare '
+                              'relative proportions across categories; identify dominant sub-groups. Query patterns: '
+                              'What is the proportion of ethnicity for each race?',
+               'name': 'vis_018_stacked_bar_proportion_stacked_normalized',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[heatmap] Shows the pre-aggregated encounter count for each combination of race and '
+                              'ethnicity as a labeled heatmap. Design: Filters to the two-dimension marginal and maps '
+                              'the measure to cell color; overlaid text shows exact values with contrast-aware color. '
+                              'The field with more categories is preferably on the y-axis. Tasks: Identify clusters or '
+                              'patterns across two dimensions; compare counts across combinations. Query patterns: Are '
+                              'there clusters in encounter count across race and ethnicity?; Make a heatmap of race '
+                              'and ethnicity.',
+               'name': 'vis_019_heatmap_count',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[table] Shows the grand-total encounter count as a single-row table. Design: Reads the '
+                              'grand-total row directly by filtering to the marginal where every dimension is empty; '
+                              'no aggregation is performed. Tasks: Retrieve the overall total. Query patterns: How '
+                              'many encounters are there in total?; What is the total encounter count?',
+               'name': 'vis_020_table_count',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[table] Lists each encounter class with its pre-aggregated encounter count as a sorted '
+                              'table with in-cell bars. Design: Filters to the encounter class marginal, orders by the '
+                              'measure, and adds in-cell bars for visual comparison. Tasks: Determine the distinct '
+                              'values of a dimension; compare category counts. Query patterns: List the encounter '
+                              'count for each encounter class.; What is the range of encounter class values?',
+               'name': 'vis_021_table_count_sorted',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[table] Lists each gender with its pre-aggregated encounter count as a sorted table '
+                              'with in-cell bars. Design: Filters to the gender marginal, orders by the measure, and '
+                              'adds in-cell bars for visual comparison. Tasks: Determine the distinct values of a '
+                              'dimension; compare category counts. Query patterns: List the encounter count for each '
+                              'gender.; What is the range of gender values?',
+               'name': 'vis_022_table_count_sorted',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[table] Lists each race with its pre-aggregated encounter count as a sorted table with '
+                              'in-cell bars. Design: Filters to the race marginal, orders by the measure, and adds '
+                              'in-cell bars for visual comparison. Tasks: Determine the distinct values of a '
+                              'dimension; compare category counts. Query patterns: List the encounter count for each '
+                              'race.; What is the range of race values?',
+               'name': 'vis_023_table_count_sorted',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'},
+ {'function': {'description': '[table] Lists each ethnicity with its pre-aggregated encounter count as a sorted table '
+                              'with in-cell bars. Design: Filters to the ethnicity marginal, orders by the measure, '
+                              'and adds in-cell bars for visual comparison. Tasks: Determine the distinct values of a '
+                              'dimension; compare category counts. Query patterns: List the encounter count for each '
+                              'ethnicity.; What is the range of ethnicity values?',
+               'name': 'vis_024_table_count_sorted',
+               'parameters': {'additionalProperties': False,
+                              'properties': {'entity': {'description': 'The data entity (table) to visualize.',
+                                                        'type': 'string'}},
+                              'required': ['entity'],
+                              'type': 'object'}},
+  'type': 'function'}]
+
+
+# Dispatch: tool name -> (template_index, param_to_binding_map)
+TOOL_DISPATCH = {'vis_000_barchart_count_horiz': (0, {'entity': 'E'}),
+ 'vis_001_barchart_count_vert': (1, {'entity': 'E'}),
+ 'vis_002_barchart_count_horiz': (2, {'entity': 'E'}),
+ 'vis_003_barchart_count_vert': (3, {'entity': 'E'}),
+ 'vis_004_barchart_count_vert': (4, {'entity': 'E'}),
+ 'vis_005_line_count': (5, {'entity': 'E'}),
+ 'vis_006_circular_count': (6, {'entity': 'E'}),
+ 'vis_007_circular_count': (7, {'entity': 'E'}),
+ 'vis_008_stacked_bar_count_vert_stacked': (8, {'entity': 'E'}),
+ 'vis_009_stacked_bar_count_grouped': (9, {'entity': 'E'}),
+ 'vis_010_stacked_bar_count_stacked_normalized': (10, {'entity': 'E'}),
+ 'vis_011_heatmap_count': (11, {'entity': 'E'}),
+ 'vis_012_stacked_bar_count_vert_stacked': (12, {'entity': 'E'}),
+ 'vis_013_stacked_bar_count_grouped': (13, {'entity': 'E'}),
+ 'vis_014_stacked_bar_proportion_stacked_normalized': (14, {'entity': 'E'}),
+ 'vis_015_heatmap_count': (15, {'entity': 'E'}),
+ 'vis_016_stacked_bar_count_vert_stacked': (16, {'entity': 'E'}),
+ 'vis_017_stacked_bar_count_grouped': (17, {'entity': 'E'}),
+ 'vis_018_stacked_bar_proportion_stacked_normalized': (18, {'entity': 'E'}),
+ 'vis_019_heatmap_count': (19, {'entity': 'E'}),
+ 'vis_020_table_count': (20, {'entity': 'E'}),
+ 'vis_021_table_count_sorted': (21, {'entity': 'E'}),
+ 'vis_022_table_count_sorted': (22, {'entity': 'E'}),
+ 'vis_023_table_count_sorted': (23, {'entity': 'E'}),
+ 'vis_024_table_count_sorted': (24, {'entity': 'E'})}

--- a/src/udiagent/vis_generate.py
+++ b/src/udiagent/vis_generate.py
@@ -20,6 +20,51 @@ from udiagent.schema import simplify_data_schema, simplify_data_domains
 
 
 # ---------------------------------------------------------------------------
+# Active template set (hard-coded developer switch)
+# ---------------------------------------------------------------------------
+#
+# YAC ships two template sets: the default "line_item" set (tidy per-record
+# tables) and a "cube" set (pre-aggregated powerset cubes, where re-aggregation
+# is wrong and per-record charts are impossible). To point the pipeline at a
+# different set, change ACTIVE_TEMPLATE_SET below and restart. This is
+# deliberately a single hard-coded value — there is no schema-based
+# auto-detection.
+#
+# Each entry names (a) the packaged few-shot examples JSON and (b) the generated
+# typed-tools module. After editing/regenerating a set, rebuild its tools with:
+#     python scripts/regenerate_vis_tools.py --template-set cube
+ACTIVE_TEMPLATE_SET = "line_item"
+
+_TEMPLATE_SETS = {
+    "line_item": {
+        "examples_file": "template_visualizations.json",
+        "tools_module": "udiagent.generated_vis_tools",
+    },
+    "cube": {
+        "examples_file": "template_visualizations_cube.json",
+        "tools_module": "udiagent.generated_vis_tools_cube",
+    },
+}
+
+
+def _active_template_set() -> dict:
+    """Return the config for the currently selected template set."""
+    if ACTIVE_TEMPLATE_SET not in _TEMPLATE_SETS:
+        raise ValueError(
+            f"Unknown ACTIVE_TEMPLATE_SET {ACTIVE_TEMPLATE_SET!r}; "
+            f"expected one of {sorted(_TEMPLATE_SETS)}"
+        )
+    return _TEMPLATE_SETS[ACTIVE_TEMPLATE_SET]
+
+
+def _default_examples_path() -> str:
+    """Packaged few-shot examples path for the active template set."""
+    return str(
+        _package_data_path() / "skills" / _active_template_set()["examples_file"]
+    )
+
+
+# ---------------------------------------------------------------------------
 # Few-shot example loading
 # ---------------------------------------------------------------------------
 
@@ -35,7 +80,7 @@ def _load_examples(
     Returns empty string if file doesn't exist or is empty.
     """
     if examples_path is None:
-        examples_path = str(_package_data_path() / "skills" / "template_visualizations.json")
+        examples_path = _default_examples_path()
 
     if examples_path in _examples_cache:
         return _examples_cache[examples_path]
@@ -402,12 +447,16 @@ def validate_bindings(spec_template, bindings, schema):
 
 
 def _load_generated_tools():
-    """Load generated tool data. Returns (tool_defs, tool_dispatch, templates, schema) or None."""
-    try:
-        from udiagent.generated_vis_tools import TOOL_DEFS, TOOL_DISPATCH, TEMPLATES, SCHEMA
+    """Load generated tool data for the active template set.
 
-        return TOOL_DEFS, TOOL_DISPATCH, TEMPLATES, SCHEMA
-    except ImportError:
+    Returns (tool_defs, tool_dispatch, templates, schema) or None.
+    """
+    import importlib
+
+    try:
+        module = importlib.import_module(_active_template_set()["tools_module"])
+        return module.TOOL_DEFS, module.TOOL_DISPATCH, module.TEMPLATES, module.SCHEMA
+    except (ImportError, AttributeError):
         return None
 
 

--- a/tests/test_template_set_switch.py
+++ b/tests/test_template_set_switch.py
@@ -1,0 +1,126 @@
+"""Tests for the hard-coded template-set switch and the data-cube template set.
+
+These tests exercise template loading, the switch, and template instantiation
+without calling the OpenAI API.
+"""
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from udiagent import vis_generate as vg
+from udiagent.skills import _package_data_path
+
+# Chart types that require per-record data and must never appear in a cube set.
+EXCLUDED_CHART_TYPES = {
+    "scatterplot",
+    "grouped_scatter",
+    "dot",
+    "grouped_dot",
+    "histogram",
+    "area",  # KDE / density
+    "grouped_area",  # grouped KDE / density
+    "grouped_line",  # grouped CDF
+}
+
+
+@pytest.fixture
+def use_cube(monkeypatch):
+    """Point the pipeline at the cube template set for the duration of a test."""
+    monkeypatch.setattr(vg, "ACTIVE_TEMPLATE_SET", "cube")
+
+
+def _cube_templates():
+    path = _package_data_path() / "skills" / "template_visualizations_cube.json"
+    return json.loads(Path(path).read_text())
+
+
+class TestSwitch:
+    def test_default_is_line_item(self):
+        assert vg.ACTIVE_TEMPLATE_SET == "line_item"
+
+    def test_unknown_set_raises(self, monkeypatch):
+        monkeypatch.setattr(vg, "ACTIVE_TEMPLATE_SET", "nope")
+        with pytest.raises(ValueError):
+            vg._active_template_set()
+
+    def test_examples_path_follows_switch(self, use_cube):
+        assert vg._default_examples_path().endswith("template_visualizations_cube.json")
+
+    def test_generated_tools_follow_switch(self, use_cube):
+        loaded = vg._load_generated_tools()
+        assert loaded is not None
+        tool_defs, tool_dispatch, templates, schema = loaded
+        assert "encounter_counts" in schema["entities"]
+        assert len(tool_defs) == len(templates) == 25
+
+    def test_line_item_tools_still_load(self):
+        loaded = vg._load_generated_tools()
+        assert loaded is not None
+        tool_defs, _, templates, _ = loaded
+        assert len(tool_defs) == len(templates) > 0
+
+    def test_cube_few_shot_examples_load(self, use_cube):
+        examples = vg._load_examples(None)
+        assert examples.strip()
+        assert "marginal" in examples.lower()
+
+
+class TestCubeTemplateSet:
+    def test_no_excluded_chart_types(self):
+        chart_types = {t["chart_type"] for t in _cube_templates()}
+        assert not (chart_types & EXCLUDED_CHART_TYPES)
+
+    def test_all_specs_validate_against_grammar(self):
+        grammar = json.loads(
+            (_package_data_path() / "UDIGrammarSchema.json").read_text()
+        )
+        for t in _cube_templates():
+            spec = json.loads(t["spec_template"])
+            jsonschema.validate(instance=spec, schema=grammar)
+
+    def test_every_template_filters_all_dimensions(self):
+        # A cube read must be a marginal: every dimension appears in the filter,
+        # exactly one clause per dimension (present-or-empty), never a re-count.
+        schema = json.loads(
+            (Path(__file__).resolve().parent.parent
+             / "data" / "data_domains" / "encounter_cube_schema.json").read_text()
+        )
+        resource = schema["resources"][0]
+        dims = resource["udi:dimensions"]
+        for t in _cube_templates():
+            spec = json.loads(t["spec_template"])
+            transforms = spec.get("transformation", [])
+            filters = [tr["filter"] for tr in transforms if "filter" in tr]
+            assert filters, f"{t['chart_type']} template has no marginal filter"
+            filter_expr = filters[0]
+            for d in dims:
+                assert f"d['{d}']" in filter_expr, (
+                    f"dimension {d} missing from filter of {t['chart_type']}"
+                )
+
+    def test_no_count_rollup_over_raw_rows(self):
+        # The cube is pre-aggregated: count() must never be used. Sums of the
+        # measure (after a marginal filter) are allowed.
+        for t in _cube_templates():
+            assert '"op": "count"' not in t["spec_template"], (
+                f"{t['chart_type']} re-counts raw rows"
+            )
+
+
+class TestCubeInstantiation:
+    def test_templates_instantiate_and_validate_bindings(self, use_cube):
+        tool_defs, tool_dispatch, templates, schema = vg._load_generated_tools()
+        for tool_def in tool_defs:
+            name = tool_def["function"]["name"]
+            template_idx, param_map = tool_dispatch[name]
+            # The cube tools take only an entity argument.
+            bindings = {"E": "encounter_counts"}
+            errors = vg.validate_bindings(templates[template_idx], bindings, schema)
+            assert errors == [], f"{name}: {errors}"
+            spec = vg.instantiate_template(templates[template_idx], bindings, schema)
+            assert spec["source"]["source"].endswith(
+                "core__count_encounter_month.csv"
+            )


### PR DESCRIPTION
## Summary
- Adds a parallel **data-cube** template set for pre-aggregated powerset cubes, alongside the existing line-item set.
- On a cube there are no raw rows to re-aggregate, so each template **filters to the marginal rows** (the active dimensions non-null and every other dimension null) and maps the measure directly; proportional charts apply that marginal filter first, then compute proportions.
- Chart types that require per-record data (scatterplot, grouped_scatter, dot, grouped_dot, histogram, CDF/KDE/density) are omitted as impossible on a cube.
- A single hard-coded switch (`ACTIVE_TEMPLATE_SET`) selects the active set; no schema-based auto-detection.

## Changes
- `data/data_domains/encounter_cube_{schema,domains}.json` — UDI schema/domains for the Cumulus count-cube (mirrors the penguins files). `cnt` is the measure; six dimensions; `age_at_visit`→quantitative and `period_start_month`→temporal (encoded ordinal) to sidestep the >50-cardinality nominal cap. **The raw cube data files (CSV/parquet/dictionary) are gitignored, not committed** — keep them locally under `data/example_data_cube/`.
- `scripts/template_viz_generation_cube.py` — cube template generator (plain-dict specs, no `udi_grammar_py` dep); reads the cube **schema** (not the raw data) and validates every spec against `UDIGrammarSchema.json`. Produces `src/udiagent/data/skills/template_visualizations_cube.json` (25 templates: bar, line-over-time, pie/donut, stacked/grouped/normalized bar, heatmap, tables).
- `src/udiagent/generated_vis_tools_cube.py` — typed tools generated from the cube templates + cube schema (25 tools).
- `src/udiagent/vis_generate.py` — `ACTIVE_TEMPLATE_SET` + registry; both the `examples_path` default and the generated-tools import resolve through it.
- `scripts/regenerate_vis_tools.py` — `--template-set {line_item,cube}` to rebuild either set in one command (also fixes the stale `generate_tools.py` path and teaches the line-item generator to honor `-o`).
- `tests/test_template_set_switch.py` — 11 tests (no OpenAI calls).

## Spec
`.claude/todo/done/add-data-cube-visualization-template-set.md`

## Test plan
- `python -m pytest` — full suite passes (41 tests), including the new switch/cube coverage.
- `python scripts/regenerate_vis_tools.py --template-set cube` — deterministically reproduces the committed cube templates + tools (reads the schema, not the raw data).
- To try the cube set end-to-end, set `ACTIVE_TEMPLATE_SET = "cube"` in `vis_generate.py` and run a query against the `encounter_counts` cube. **Note:** OpenAI-dependent end-to-end runs were intentionally not executed (per the spec); the tests validate loading, instantiation, and grammar conformance without the API.

### Known considerations
- Cube templates are concrete to this fixture's dimensions (the marginal filter must name every other dimension), so they are dataset-specific by design.
- The month axis is encoded `ordinal` (the grammar has no temporal type); ordering is by the raw `M/D/YYYY` string, so chronological sort isn't guaranteed.
- The marginal filter uses `== null` / `!= null`, matching existing template convention; if a data loader represents empty CSV cells as `""` rather than `null`, the expression would need adjusting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
